### PR TITLE
Add GitHub Actions workflow for Maven package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,53 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Maven Package
+
+on:
+  workflow_dispatch:
+  push: 
+    tags:
+      - v*
+  pull_request:
+    branches: [ "main" ]
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # permissions:
+    #   contents: read
+    #   packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+        # server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        # settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    # # Add step to read version and check if SNAPSHOT
+    # - name: Check version for workflow_dispatch
+    #   if: github.event_name == 'workflow_dispatch'
+    #   run: |
+    #     VERSION=$(grep "def gJEXVersion = " build.gradle | cut -d"'" -f2)
+    #     if [[ ! $VERSION =~ .*SNAPSHOT$ ]]; then
+    #       echo "Error: Manual workflow runs are only allowed for SNAPSHOT versions"
+    #       echo "Current version: $VERSION"
+    #       exit 1
+    #     fi
+    #     echo "Version $VERSION is a SNAPSHOT version, proceeding with publish"
+
+    - name: Build with Maven
+      run: mvn -B package 
+
+    # - name: Publish to GitHub Packages Apache Maven
+    #   run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+    #   env:
+    #     CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
+    #     CLOJARS_PASSWORD: ${{ secrets.CLOJARS_TOKEN }}


### PR DESCRIPTION
This workflow builds a Maven package and publishes it to GitHub packages upon release creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Added GitHub Actions continuous integration workflow to automate Maven project building and packaging. The workflow is triggered on version releases, pull requests to the main branch, and manual dispatch events. Includes automatic environment configuration and project compilation. Establishes the foundation for consistent continuous integration and future deployment automation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->