### PR TITLE
MavenCentral Publish Fixes 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,63 +1,68 @@
 # This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
-# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+# Publish to Maven Central with GPG-signed artifacts.
+# Requires secrets: CENTRAL_USERNAME, CENTRAL_TOKEN, GPG_PRIVATE_KEY, GPG_PASSPHRASE
 
 name: Publish Package to the Maven Central
 
 on:
   workflow_dispatch:
-  push: 
+  push:
     tags:
       - v*
-  # pull_request:
-  #   branches: [ "main" ]
-    
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     env:
       CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
       CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
-    # permissions:
-    #   contents: read
-    #   packages: write
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'adopt'
-        cache: 'maven'   # Enable Maven caching
-        server-id: central # Value of the distributionManagement/repository/id field of the pom.xml
-        server-username: CENTRAL_USERNAME  # env variable for username
-        server-password: CENTRAL_TOKEN # env variable for password / deploy token
-        settings-path: ${{ github.workspace }} # location for the settings.xml file
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+          cache: 'maven'
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_TOKEN
+          settings-path: ${{ github.workspace }}
 
-    - name: Ensure SNAPSHOT revision for workflow_dispatch
-      if: github.event_name == 'workflow_dispatch'
-      run: |
-        REVISION=$(python3 <<'PY'
-        import xml.etree.ElementTree as ET
-        tree = ET.parse("pom.xml")
-        ns = {"mvn": "http://maven.apache.org/POM/4.0.0"}
-        revision = tree.findtext("mvn:properties/mvn:revision", namespaces=ns)
-        if revision is None:
-            raise SystemExit("Unable to locate <revision> in pom.xml")
-        print(revision.strip())
-        PY
-        )
-        echo "Detected revision: ${REVISION}"
-        if [[ "${REVISION}" != *SNAPSHOT ]]; then
-          echo "Error: workflow_dispatch runs are allowed only for SNAPSHOT revisions."
-          exit 1
-        fi
-        echo "Revision ${REVISION} is a SNAPSHOT; continuing."
+      - name: Set up GPG for signing
+        run: |
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --yes --pinentry-mode loopback --import
+          # List secret keys so we can use the only key (or set gpg.keyid in Maven if you have multiple)
+          gpg --list-secret-keys --keyid-format=long
 
-    - name: Build with Maven
-      run: mvn -B package 
+      - name: Ensure SNAPSHOT revision for workflow_dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          REVISION=$(python3 <<'PY'
+          import xml.etree.ElementTree as ET
+          tree = ET.parse("pom.xml")
+          ns = {"mvn": "http://maven.apache.org/POM/4.0.0"}
+          revision = tree.findtext("mvn:properties/mvn:revision", namespaces=ns)
+          if revision is None:
+              raise SystemExit("Unable to locate <revision> in pom.xml")
+          print(revision.strip())
+          PY
+          )
+          echo "Detected revision: ${REVISION}"
+          if [[ "${REVISION}" != *SNAPSHOT ]]; then
+            echo "Error: workflow_dispatch runs are allowed only for SNAPSHOT revisions."
+            exit 1
+          fi
+          echo "Revision ${REVISION} is a SNAPSHOT; continuing."
 
-    - name: Publish to Maven Central
-      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      - name: Build with Maven
+        run: mvn -B package 
+
+      - name: Build and publish to Maven Central (with GPG signing)
+        run: mvn -B deploy -s $GITHUB_WORKSPACE/settings.xml
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,4 +65,5 @@ jobs:
         run: mvn -B deploy -s $GITHUB_WORKSPACE/settings.xml
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }} # Setting both as of now.
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -59,6 +59,8 @@
     <modelVersion>4.0.0</modelVersion>
     <version>${revision}</version>
     <artifactId>api</artifactId>
+    <name>Drift API</name>
+    <description>Drift API application and bootstrap for running workflow APIs.</description>
     <dependencies>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -10,6 +10,14 @@
     </parent>
     <build>
         <plugins>
+            <!-- Do not publish this module to Maven Central; only java-sdk and api are published -->
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -13,6 +13,8 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>commons</artifactId>
     <version>${revision}</version>
+    <name>Drift Commons</name>
+    <description>Shared utilities and entities for Drift (HBase, serialization, validation).</description>
 
     <dependencies>
         <dependency>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -125,6 +125,14 @@
     </properties>
     <build>
         <plugins>
+            <!-- Do not publish this module to Maven Central; only java-sdk and api are published -->
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -10,7 +10,8 @@
     </parent>
 
     <artifactId>java-sdk</artifactId>
-    <description>Java SDK for Drift containing public models and SPIs</description>
+    <name>Drift Java SDK</name>
+    <description>Java SDK for Drift containing public models and SPIs.</description>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 
     <scm>
         <connection>scm:git:git://github.com/flipkart-incubator/drift.git</connection>
-        <developerConnection>scm:git:ssh://github.com:flipkart-incubator/drift.git</developerConnection>
+        <developerConnection>scm:git:ssh://git@github.com/flipkart-incubator/drift.git</developerConnection>
         <url>https://github.com/flipkart-incubator/drift</url>
         <tag>HEAD</tag>
     </scm>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>${revision}</version>
 
     <properties>
-        <revision>1.0-SNAPSHOT</revision>
+        <revision>1.0.0-rc1</revision>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>${revision}</version>
 
     <properties>
-        <revision>1.0.SNAPSHOT</revision>
+        <revision>1.0-SNAPSHOT</revision>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -482,6 +482,14 @@
                     <doclint>none</doclint>
                     <source>17</source>
                     <skip>${attach.javadoc.skip}</skip>
+                    <!-- Lombok is provided-scope; add to classpath so Javadoc can resolve annotations -->
+                    <additionalDependencies>
+                        <additionalDependency>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </additionalDependency>
+                    </additionalDependencies>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <maven.source.plugin.version>3.3.0</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.6.2</maven.javadoc.plugin.version>
         <maven.gpg.plugin.version>3.2.1</maven.gpg.plugin.version>
+        <lombok.maven.plugin.version>1.18.20.0</lombok.maven.plugin.version>
         <attach.sources.skip>false</attach.sources.skip>
         <attach.javadoc.skip>false</attach.javadoc.skip>
     </properties>
@@ -128,6 +129,46 @@
             <modules>
                 <module>worker</module>
             </modules>
+        </profile>
+        <!-- Delombok + Javadoc sourcepath: only for modules with src/main/java (skip parent) -->
+        <profile>
+            <id>delombok-for-javadoc</id>
+            <activation>
+                <file>
+                    <exists>src/main/java</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok-maven-plugin</artifactId>
+                        <version>${lombok.maven.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>delombok</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>delombok</goal>
+                                </goals>
+                                <configuration>
+                                    <sourceDirectory>src/main/java</sourceDirectory>
+                                    <outputDirectory>${project.build.directory}/generated-sources/delombok</outputDirectory>
+                                    <addOutputDirectory>false</addOutputDirectory>
+                                    <encoding>${project.build.sourceEncoding}</encoding>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <sourcepath>${project.build.directory}/generated-sources/delombok</sourcepath>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 
@@ -482,14 +523,6 @@
                     <doclint>none</doclint>
                     <source>17</source>
                     <skip>${attach.javadoc.skip}</skip>
-                    <!-- Lombok is provided-scope; add to classpath so Javadoc can resolve annotations -->
-                    <additionalDependencies>
-                        <additionalDependency>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                            <version>${lombok.version}</version>
-                        </additionalDependency>
-                    </additionalDependencies>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,16 @@
         <central.publishing.plugin.version>0.9.0</central.publishing.plugin.version>
         <flatten.plugin.version>1.6.0</flatten.plugin.version>
         <surefire.plugin.version>3.1.2</surefire.plugin.version>
+        <maven.source.plugin.version>3.3.0</maven.source.plugin.version>
+        <maven.javadoc.plugin.version>3.6.2</maven.javadoc.plugin.version>
+        <maven.gpg.plugin.version>3.2.1</maven.gpg.plugin.version>
+        <attach.sources.skip>false</attach.sources.skip>
+        <attach.javadoc.skip>false</attach.javadoc.skip>
     </properties>
+
+    <name>Drift Parent</name>
+    <description>A Temporal-powered, low-code workflow builder and execution platform that lets users design and run workflows with native nodes.</description>
+    <url>https://github.com/flipkart-incubator/drift</url>
 
     <licenses>
         <license>
@@ -58,6 +67,20 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <scm>
+        <connection>scm:git:git://github.com/flipkart-incubator/drift.git</connection>
+        <developerConnection>scm:git:ssh://github.com:flipkart-incubator/drift.git</developerConnection>
+        <url>https://github.com/flipkart-incubator/drift</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <developers>
+        <developer>
+            <organization>Flipkart</organization>
+            <organizationUrl>https://github.com/flipkart-incubator</organizationUrl>
+        </developer>
+    </developers>
 
     <repositories>
         <repository>
@@ -433,6 +456,62 @@
                         <include>**/*IT.java</include>
                     </includes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven.source.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                        <configuration>
+                            <skipSource>${attach.sources.skip}</skipSource>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.plugin.version}</version>
+                <configuration>
+                    <doclint>none</doclint>
+                    <source>17</source>
+                    <skip>${attach.javadoc.skip}</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>${maven.gpg.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>${revision}</version>
 
     <properties>
-        <revision>1.0.0-rc1</revision>
+        <revision>1.0.SNAPSHOT</revision>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -241,6 +241,14 @@
     </properties>
     <build>
         <plugins>
+            <!-- Do not publish this module to Maven Central; only java-sdk and api are published -->
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -12,6 +12,8 @@
 
     <artifactId>worker</artifactId>
     <version>${revision}</version>
+    <name>Drift Worker</name>
+    <description>Drift Worker runtime for executing workflow tasks.</description>
 
     <distributionManagement>
         <repository>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced Maven Central publishing workflow to include GPG signing and streamlined deploy process.
  * Added public project metadata (names, descriptions, URL, SCM, developers) across modules and parent POM.
  * Added source/javadoc attachments and signing support; introduced per-module controls to skip publishing to Maven Central.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->