### PR TITLE
Add configurable Redis database index (support DB other than 0)

### DIFF
--- a/api/src/main/java/com/flipkart/drift/api/config/RedisConfiguration.java
+++ b/api/src/main/java/com/flipkart/drift/api/config/RedisConfiguration.java
@@ -18,6 +18,7 @@ public class RedisConfiguration {
     private int maxWaitMillis;
     private boolean testOnBorrow;
     private boolean blockWhenExhausted;
+    private int database;
 }
 
 

--- a/api/src/main/java/com/flipkart/drift/api/module/WorkflowClientModule.java
+++ b/api/src/main/java/com/flipkart/drift/api/module/WorkflowClientModule.java
@@ -183,5 +183,3 @@ public class WorkflowClientModule extends AbstractModule {
     }
 
 }
-
-

--- a/api/src/main/java/com/flipkart/drift/api/module/WorkflowClientModule.java
+++ b/api/src/main/java/com/flipkart/drift/api/module/WorkflowClientModule.java
@@ -184,3 +184,4 @@ public class WorkflowClientModule extends AbstractModule {
 
 }
 
+

--- a/api/src/main/java/com/flipkart/drift/api/module/WorkflowClientModule.java
+++ b/api/src/main/java/com/flipkart/drift/api/module/WorkflowClientModule.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.security.UserGroupInformation;
 import redis.clients.jedis.JedisSentinelPool;
+import redis.clients.jedis.Protocol;
 
 import java.util.*;
 
@@ -49,7 +50,8 @@ public class WorkflowClientModule extends AbstractModule {
                 hostList.add(strTkn.nextToken());
             Set<String> sentinels = new HashSet<>(hostList);
             GenericObjectPoolConfig<?> genericObjectPoolConfig = getGenericObjectPoolConfig(redisConfiguration);
-            return new JedisSentinelPool(redisConfiguration.getMaster(), sentinels, genericObjectPoolConfig, redisConfiguration.getPassword());
+            return new JedisSentinelPool(redisConfiguration.getMaster(), sentinels, genericObjectPoolConfig,
+                    Protocol.DEFAULT_TIMEOUT, redisConfiguration.getPassword(), redisConfiguration.getDatabase());
         } catch (Exception e) {
             log.error("Failed to Connected to RedisDao Server {}", e.getMessage(), e);
             return null;

--- a/api/src/main/resources/config/configuration.yaml
+++ b/api/src/main/resources/config/configuration.yaml
@@ -22,6 +22,7 @@ redisConfiguration:
   master: ${REDIS_MASTER}
   sentinels: ${REDIS_SENTINELS}
   prefix: ${REDIS_PREFIX}
+  database: ${REDIS_DATABASE:-0}
   maxTotal: 50
   maxWaitMillis: 100
   maxIdle: 25

--- a/examples/worker-flipkart/README.md
+++ b/examples/worker-flipkart/README.md
@@ -610,6 +610,7 @@ REDIS_PASSWORD=your-redis-password
 REDIS_MASTER=redis-master-hostname
 REDIS_SENTINELS=redis-sentinel1:26379,redis-sentinel2:26379
 REDIS_PREFIX=drift-local
+REDIS_DATABASE=0
 
 # Config File Paths (relative to worker module)
 ENUM_STORE_BUCKET=src/main/resources/config/lookup.properties

--- a/package/helm-chart/api/templates/configmap.yaml
+++ b/package/helm-chart/api/templates/configmap.yaml
@@ -29,6 +29,7 @@ data:
       master: {{ .Values.env.REDIS_MASTER }}
       sentinels: {{ .Values.env.REDIS_SENTINELS }}
       prefix: {{ .Values.env.REDIS_PREFIX }}
+      database: {{ .Values.env.REDIS_DATABASE | default "0" }}
       maxTotal: 50
       maxWaitMillis: 100
       maxIdle: 25

--- a/package/helm-chart/api/values.yaml
+++ b/package/helm-chart/api/values.yaml
@@ -31,6 +31,7 @@ env:
   REDIS_MASTER: "your-redis-master"
   REDIS_SENTINELS: "your-redis-sentinel:26379"
   REDIS_PREFIX: "drift"
+  REDIS_DATABASE: "0"
   HBASE_CONFIG_BUCKET: "file:////usr/share/drift-api/config/hbase.properties"
   TEMPORAL_FRONTEND: "your-temporal-frontend:7233"
   TEMPORAL_TASK_QUEUE: "DRIFT_QUEUE"

--- a/package/helm-chart/worker/values.yaml
+++ b/package/helm-chart/worker/values.yaml
@@ -74,6 +74,7 @@ configFiles:
       master: ${REDIS_MASTER}
       sentinels: ${REDIS_SENTINELS}
       prefix: ${REDIS_PREFIX}
+      database: ${REDIS_DATABASE:-0}
       maxTotal: 50
       maxWaitMillis: 100
       maxIdle: 25

--- a/package/helm-chart/worker/values.yaml
+++ b/package/helm-chart/worker/values.yaml
@@ -31,6 +31,7 @@ env:
   REDIS_MASTER: "your-redis-master"
   REDIS_SENTINELS: "your-redis-sentinel:26379"
   REDIS_PREFIX: "drift"
+  REDIS_DATABASE: "0"
   ENUM_STORE_BUCKET: "file:////usr/share/drift-worker/config/lookup.properties"
   HBASE_CONFIG_BUCKET: "file:////usr/share/drift-worker/config/hbase.properties"
   AB_CONFIG_BUCKET: "file:////usr/share/drift-worker/config/ab.properties"

--- a/worker/src/main/java/com/flipkart/drift/worker/activities/ReturnControlActivityImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/activities/ReturnControlActivityImpl.java
@@ -31,4 +31,3 @@ public class ReturnControlActivityImpl implements ReturnControlActivity {
         return status;
     }
 }
-

--- a/worker/src/main/java/com/flipkart/drift/worker/activities/ReturnControlActivityImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/activities/ReturnControlActivityImpl.java
@@ -31,3 +31,4 @@ public class ReturnControlActivityImpl implements ReturnControlActivity {
         return status;
     }
 }
+

--- a/worker/src/main/java/com/flipkart/drift/worker/bootstrap/WorkerModule.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/bootstrap/WorkerModule.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.security.UserGroupInformation;
 import redis.clients.jedis.JedisPoolAbstract;
 import redis.clients.jedis.JedisSentinelPool;
+import redis.clients.jedis.Protocol;
 
 import javax.ws.rs.core.Response;
 import java.util.*;
@@ -59,7 +60,8 @@ public class WorkerModule extends AbstractModule {
             while (strTkn.hasMoreTokens()) hostList.add(strTkn.nextToken());
             Set<String> sentinels = new HashSet<>(hostList);
             GenericObjectPoolConfig<?> genericObjectPoolConfig = getGenericObjectPoolConfig(redisConfiguration);
-            return new JedisSentinelPool(redisConfiguration.getMaster(), sentinels, genericObjectPoolConfig, redisConfiguration.getPassword());
+            return new JedisSentinelPool(redisConfiguration.getMaster(), sentinels, genericObjectPoolConfig,
+                    Protocol.DEFAULT_TIMEOUT, redisConfiguration.getPassword(), redisConfiguration.getDatabase());
         } catch (Exception e) {
             log.error("Failed to Connected to RedisDao Server " + e.getMessage(), e);
             throw new RedisStoreException(Response.Status.INTERNAL_SERVER_ERROR, "Unable to init redis config", e.getMessage());

--- a/worker/src/main/java/com/flipkart/drift/worker/config/RedisConfiguration.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/config/RedisConfiguration.java
@@ -18,4 +18,5 @@ public class RedisConfiguration {
     private int maxWaitMillis;
     private boolean testOnBorrow;
     private boolean blockWhenExhausted;
+    private int database;
 }

--- a/worker/src/main/resources/config/configuration.yaml
+++ b/worker/src/main/resources/config/configuration.yaml
@@ -12,6 +12,7 @@ redisConfiguration:
   master: ${REDIS_MASTER}
   sentinels: ${REDIS_SENTINELS}
   prefix: ${REDIS_PREFIX}
+  database: ${REDIS_DATABASE:-0}
   maxTotal: 50
   maxWaitMillis: 100
   maxIdle: 25


### PR DESCRIPTION
## Summary
Adds support for using a Redis logical database other than the default DB 0 (e.g. DB 1). Useful for isolating Drift’s Redis usage from other apps on the same cluster or for multi-tenant setups.

## Changes
- **Config**: New `database` field in `RedisConfiguration` (API and worker). Default remains 0 when not set.
- **Connection**: `JedisSentinelPool` is created with the 6-arg constructor `(masterName, sentinels, poolConfig, timeout, password, database)` so all pool connections use the configured DB.
- **Config / Helm**: 
  - YAML: `database: ${REDIS_DATABASE:-0}` in API and worker configs.
  - Helm: `REDIS_DATABASE` supported in API configmap and worker config with `| default "0"` and `${REDIS_DATABASE:-0}` so existing deploys keep using DB 0.

## Usage
- **Env**: Set `REDIS_DATABASE=1` (or desired index 0–15).
- **YAML**: Set `redisConfiguration.database: 1`.
- **Helm**: Set `env.REDIS_DATABASE: "1"` in values.

Backward compatible: if `REDIS_DATABASE` is not set, behavior is unchanged (DB 0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting a Redis database index. Set via REDIS_DATABASE (env var), default 0.
  * This setting is available for both API and worker components, and included in Helm charts, configuration templates, and example docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->