### PR TITLE
Update secrets for Maven Central publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
-      CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+      CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+      GPG_PASSPHRASE: ${{ secrets.FOSS_GPG_PASSPHRASE }}
 
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
 
       - name: Set up GPG for signing
         run: |
-          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --yes --pinentry-mode loopback --import
+          echo "${{ secrets.FOSS_GPG_KEY }}" | gpg --batch --yes --pinentry-mode loopback --import
           # List secret keys so we can use the only key (or set gpg.keyid in Maven if you have multiple)
           gpg --list-secret-keys --keyid-format=long
 
@@ -64,6 +64,5 @@ jobs:
       - name: Build and publish to Maven Central (with GPG signing)
         run: mvn -B deploy -s $GITHUB_WORKSPACE/settings.xml
         env:
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }} # Setting both as of now.
-
+          GPG_PASSPHRASE: ${{ secrets.FOSS_GPG_PASSPHRASE }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.FOSS_GPG_PASSPHRASE }} # Setting both as of now.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
-      CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+      CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+      CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
       GPG_PASSPHRASE: ${{ secrets.FOSS_GPG_PASSPHRASE }}
 
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the publishing workflow to use revised secret references for Maven Central credentials.
  * Switched GPG signing variables to new secret references and cleaned up deploy environment configuration for more reliable artifact publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->