### PR TITLE
defaultFailureNode infinite loop changes

### DIFF
--- a/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
@@ -107,7 +107,7 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
                 logger.info("WfId : {} Running node: {}", workflowId, currentNode.getInstanceName());
                 activityThinResponse = nodeExecutor.executeNode(currentNode, threadContext, workflowStartRequest);
             } catch (Exception e) {
-                currentNode = nodeExecutor.handleNodeExecutionError(e, workflow);
+                currentNode = nodeExecutor.handleNodeExecutionError(e, workflow, currentNode);
                 continue;
             }
             if (activityThinResponse != null) {

--- a/worker/src/main/java/com/flipkart/drift/worker/workflows/WorkflowNodeExecutor.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/workflows/WorkflowNodeExecutor.java
@@ -141,9 +141,23 @@ public class WorkflowNodeExecutor {
         }
     }
 
-    public WorkflowNode handleNodeExecutionError(Exception e, Workflow workflow) {
+    public WorkflowNode handleNodeExecutionError(Exception e, Workflow workflow, WorkflowNode failedNode) {
         this.workflowState.setErrorMessage("Error message: " + e.getMessage());
-        WorkflowNode fallbackNode = workflow.getStates().get(workflow.getDefaultFailureNode());
+        String defaultFailureNodeId = workflow.getDefaultFailureNode();
+
+        // If the defaultFailureNode itself has failed (after exhausting its Temporal retries),
+        // do not route back to it — that would cause an infinite loop.
+        if (failedNode != null && failedNode.getInstanceName().equals(defaultFailureNodeId)) {
+            this.workflowState.setStatus(WorkflowStatus.FAILED);
+            logger.error("DefaultFailureNode '{}' failed after exhausting all retries. Terminating workflow.",
+                    defaultFailureNodeId);
+            throw ApplicationFailure.newNonRetryableFailureWithCause(
+                    "DefaultFailureNode failed after exhausting retries: " + e.getMessage(),
+                    "DEFAULT_FAILURE_NODE_FAILED", e
+            );
+        }
+
+        WorkflowNode fallbackNode = workflow.getStates().get(defaultFailureNodeId);
         // Fail the workflow if no fallback configured
         if (fallbackNode == null) {
             this.workflowState.setStatus(WorkflowStatus.FAILED);
@@ -152,6 +166,8 @@ public class WorkflowNodeExecutor {
                     "NODE_EXECUTION_FAILED", e
             );
         }
+        logger.info("Routing to defaultFailureNode '{}' after failure of node '{}'",
+                defaultFailureNodeId, failedNode.getInstanceName());
         return fallbackNode;
     }
 

--- a/worker/src/main/java/com/flipkart/drift/worker/workflows/WorkflowNodeExecutor.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/workflows/WorkflowNodeExecutor.java
@@ -157,8 +157,15 @@ public class WorkflowNodeExecutor {
             );
         }
 
+        // Fail immediately if no defaultFailureNode configured (null-safe before map lookup)
+        if (defaultFailureNodeId == null) {
+            this.workflowState.setStatus(WorkflowStatus.FAILED);
+            throw ApplicationFailure.newNonRetryableFailureWithCause(
+                    "Failed to execute node: " + e.getMessage(),
+                    "NODE_EXECUTION_FAILED", e
+            );
+        }
         WorkflowNode fallbackNode = workflow.getStates().get(defaultFailureNodeId);
-        // Fail the workflow if no fallback configured
         if (fallbackNode == null) {
             this.workflowState.setStatus(WorkflowStatus.FAILED);
             throw ApplicationFailure.newNonRetryableFailureWithCause(
@@ -167,7 +174,7 @@ public class WorkflowNodeExecutor {
             );
         }
         logger.info("Routing to defaultFailureNode '{}' after failure of node '{}'",
-                defaultFailureNodeId, failedNode.getInstanceName());
+                defaultFailureNodeId, failedNode != null ? failedNode.getInstanceName() : "unknown");
         return fallbackNode;
     }
 

--- a/worker/src/main/resources/config/configuration.yaml
+++ b/worker/src/main/resources/config/configuration.yaml
@@ -11,7 +11,7 @@ redisConfiguration:
   password: ${REDIS_PASSWORD}
   master: ${REDIS_MASTER}
   sentinels: ${REDIS_SENTINELS}
-  prefix: ${REDIS_PREFIX}
+  prefix: "${REDIS_PREFIX}"
   maxTotal: 50
   maxWaitMillis: 100
   maxIdle: 25

--- a/worker/src/test/java/com/flipkart/drift/worker/workflows/WorkflowNodeExecutorTest.java
+++ b/worker/src/test/java/com/flipkart/drift/worker/workflows/WorkflowNodeExecutorTest.java
@@ -1,0 +1,107 @@
+package com.flipkart.drift.worker.workflows;
+
+import com.flipkart.drift.commons.model.node.Workflow;
+import com.flipkart.drift.commons.model.node.WorkflowNode;
+import com.flipkart.drift.commons.model.temporal.WorkflowState;
+import com.flipkart.drift.sdk.model.enums.WorkflowStatus;
+import io.temporal.failure.ApplicationFailure;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.slf4j.Logger;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class WorkflowNodeExecutorTest {
+
+    private WorkflowState workflowState;
+    private WorkflowNodeExecutor executor;
+
+    @BeforeEach
+    void setUp() {
+        workflowState = new WorkflowState();
+        // Workflow.getLogger() requires a Temporal execution context; mock it for unit tests
+        try (MockedStatic<io.temporal.workflow.Workflow> temporal = mockStatic(io.temporal.workflow.Workflow.class)) {
+            temporal.when(() -> io.temporal.workflow.Workflow.getLogger(any(Class.class)))
+                    .thenReturn(mock(Logger.class));
+            executor = new WorkflowNodeExecutor(workflowState);
+        }
+    }
+
+    // --- helpers ---
+
+    private WorkflowNode node(String instanceName) {
+        WorkflowNode n = new WorkflowNode();
+        n.setInstanceName(instanceName);
+        return n;
+    }
+
+    private Workflow workflow(String defaultFailureNodeId, Map<String, WorkflowNode> states) {
+        Workflow w = new Workflow();
+        w.setDefaultFailureNode(defaultFailureNodeId);
+        w.setStates(states);
+        return w;
+    }
+
+    // --- tests ---
+
+    @Test
+    void defaultFailureNodeSelfFailure_terminatesWorkflow() {
+        WorkflowNode fallbackNode = node("fallback");
+        Workflow wf = workflow("fallback", Map.of("fallback", fallbackNode));
+
+        ApplicationFailure ex = assertThrows(ApplicationFailure.class,
+                () -> executor.handleNodeExecutionError(new RuntimeException("fallback exploded"), wf, fallbackNode));
+
+        assertEquals("DEFAULT_FAILURE_NODE_FAILED", ex.getType());
+        assertEquals(WorkflowStatus.FAILED, workflowState.getStatus());
+    }
+
+    @Test
+    void normalNodeFailure_routesToFallback() {
+        WorkflowNode normalNode = node("nodeA");
+        WorkflowNode fallbackNode = node("fallback");
+        Workflow wf = workflow("fallback", Map.of("fallback", fallbackNode));
+
+        WorkflowNode result = executor.handleNodeExecutionError(new RuntimeException("nodeA failed"), wf, normalNode);
+
+        assertSame(fallbackNode, result);
+        assertNotEquals(WorkflowStatus.FAILED, workflowState.getStatus());
+    }
+
+    @Test
+    void noFallbackConfigured_terminatesWorkflow() {
+        WorkflowNode normalNode = node("nodeA");
+        Workflow wf = workflow(null, Map.of());
+
+        ApplicationFailure ex = assertThrows(ApplicationFailure.class,
+                () -> executor.handleNodeExecutionError(new RuntimeException("nodeA failed"), wf, normalNode));
+
+        assertEquals("NODE_EXECUTION_FAILED", ex.getType());
+        assertEquals(WorkflowStatus.FAILED, workflowState.getStatus());
+    }
+
+    @Test
+    void nullFailedNode_routesToFallback() {
+        WorkflowNode fallbackNode = node("fallback");
+        Workflow wf = workflow("fallback", Map.of("fallback", fallbackNode));
+
+        WorkflowNode result = executor.handleNodeExecutionError(new RuntimeException("unknown"), wf, null);
+
+        assertSame(fallbackNode, result);
+    }
+
+    @Test
+    void errorMessageAlwaysSetOnException() {
+        Workflow wf = workflow(null, Map.of());
+
+        assertThrows(ApplicationFailure.class,
+                () -> executor.handleNodeExecutionError(new RuntimeException("boom"), wf, node("nodeA")));
+
+        assertTrue(workflowState.getErrorMessage().contains("boom"));
+    }
+}


### PR DESCRIPTION
## Summary

- **Infinite loop fix**: When `defaultFailureNode` exhausts all its configured retries and still fails, `handleNodeExecutionError()` was blindly re-routing back to the same fallback node, causing an infinite execution loop. Fixed by passing the failing node identity into the handler and adding a self-reference guard that terminates the workflow with `DEFAULT_FAILURE_NODE_FAILED` instead of looping.
- **Per-node retry/timeout config**: Added `NodeRetryConfig` POJO and `timeoutSeconds` field on `WorkflowNode`, wired into Temporal `ActivityOptions` via `ActivityOptionsBuilder` + `ActivityOptionsBuilderHolder`. Platform defaults (`drift.worker.activity.default-max-attempts`, `drift.worker.activity.default-timeout-seconds`) configurable via `application.yml`.
- **Config fix**: Quote `REDIS_PREFIX` in `configuration.yaml` — the `drift:` value contains a colon that YAML parses as a mapping separator.

## Key files changed

| File | Change |
|---|---|
| `GenericWorkflowImpl.java` | Pass `currentNode` to `handleNodeExecutionError()` |
| `WorkflowNodeExecutor.java` | Self-loop guard in `handleNodeExecutionError()`; wire `ActivityOptionsBuilder` |
| `ActivityOptionsBuilder.java` | Build `ActivityOptions` from `NodeRetryConfig` + platform defaults |
| `ActivityOptionsBuilderHolder.java` | Injectable holder for `ActivityOptionsBuilder` |
| `ActivityDefaultsConfig.java` | POJO for `drift.worker.activity.*` config properties |
| `DriftWorkerConfiguration.java` | Add `activityDefaults` field |
| `WorkflowNode.java` | Add `timeoutSeconds` and `retryConfig` fields |
| `NodeRetryConfig.java` | New POJO for retry config |
| `configuration.yaml` | Quote `REDIS_PREFIX` |
| `WorkflowNodeExecutorTest.java` | Unit tests for the infinite loop guard (5 cases) |
| `ActivityOptionsBuilderTest.java` | Unit tests for retry/timeout wiring (7 cases) |

## Test plan

Verified locally in Temporal UI: `drift_infinite_loop_test` workflow triggers `failing_node` (GROOVY, throws) → routes to `failing_fallback` (HTTP, dead port) → Temporal retries exactly `maxAttempts=2` times → workflow terminates cleanly with `DEFAULT_FAILURE_NODE_FAILED`. No infinite loop observed.

Worker logs confirm the guard fires:
```
Routing to defaultFailureNode 'failing_fallback' after failure of node 'failing_node'
DefaultFailureNode 'failing_fallback' failed after exhausting all retries. Terminating workflow.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nodes now support configurable retry behavior including max attempts, retry intervals, and backoff coefficients.
  * Activity execution defaults can be configured globally with per-node overrides.
  * Workflow error handling now routes failures to configured fallback nodes for improved recovery.

* **Tests**
  * Added comprehensive test coverage for activity options and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->