### PR TITLE
Removed Issue Detail Dependency in workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ logs/
 /do-not-commit
 *-secret*
 *-secrets*
+*-credentials*
 *.key
 *.pem
 .cursor

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -137,6 +137,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.temporal</groupId>
+            <artifactId>temporal-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.wordnik</groupId>
             <artifactId>swagger-annotations</artifactId>
         </dependency>

--- a/api/src/main/java/com/flipkart/drift/api/bootstrap/DriftApplication.java
+++ b/api/src/main/java/com/flipkart/drift/api/bootstrap/DriftApplication.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.flipkart.drift.api.config.DriftConfiguration;
 import com.flipkart.drift.api.exception.mapper.ApiExceptionMapper;
+import com.flipkart.drift.api.filters.IdempotencyFilter;
 import com.flipkart.drift.api.filters.RequestFilter;
 import com.flipkart.drift.api.filters.ResponseFilter;
 import com.flipkart.drift.api.resources.WorkflowResource;
@@ -68,6 +69,7 @@ public class DriftApplication extends Application<DriftConfiguration> {
         environment.jersey().register(injector.getInstance(NodeDefinitionResource.class));
         environment.jersey().register(injector.getInstance(WorkflowDefinitionResource.class));
         environment.jersey().register(injector.getInstance(RequestFilter.class));
+        environment.jersey().register(injector.getInstance(IdempotencyFilter.class));
         environment.jersey().register(injector.getInstance(ResponseFilter.class));
         environment.jersey().register(injector.getInstance(ApiExceptionMapper.class));
         final JmxReporter reporter = JmxReporter.forRegistry(metricRegistry).build();

--- a/api/src/main/java/com/flipkart/drift/api/client/CacheInvalidationClient.java
+++ b/api/src/main/java/com/flipkart/drift/api/client/CacheInvalidationClient.java
@@ -1,0 +1,101 @@
+package com.flipkart.drift.api.client;
+
+import com.flipkart.drift.api.config.DriftConfiguration;
+import com.flipkart.drift.api.config.WorkerInvalidationConfig;
+import lombok.extern.slf4j.Slf4j;
+import redis.clients.jedis.JedisSentinelPool;
+
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import static com.flipkart.drift.api.service.utils.Utility.publishRedisEvent;
+import static com.flipkart.drift.commons.utils.Constants.Workflow.DSL_UPDATE_CHANNEL;
+
+/**
+ * Publishes DSL cache invalidation events to all worker pods.
+ * Strategy:
+ *   - Redis enabled and pool available → publish to DSL_UPDATE_CHANNEL (existing behaviour).
+ *   - Redis disabled → DNS fanout: resolve K8s headless service → POST to each worker pod's admin task endpoint.
+ */
+@Slf4j
+public class CacheInvalidationClient {
+
+    private final boolean redisEnabled;
+    private final JedisSentinelPool jedisSentinelPool;
+    private final WorkerInvalidationConfig workerInvalidationConfig;
+
+    public CacheInvalidationClient(DriftConfiguration driftConfiguration, JedisSentinelPool jedisSentinelPool) {
+        this.redisEnabled = driftConfiguration.getRedisConfiguration().isRedisEnabled();
+        this.jedisSentinelPool = jedisSentinelPool;
+        this.workerInvalidationConfig = driftConfiguration.getWorkerInvalidationConfig();
+    }
+
+    /**
+     * Invalidates the cache entry for the given key on all worker pods.
+     *
+     * @param cacheType  "NODE" or "WORKFLOW"
+     * @param key        HBase row key to invalidate, or "ALL"
+     */
+    public void invalidate(String cacheType, String key) {
+        if (redisEnabled && jedisSentinelPool != null) {
+            publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, cacheType + " " + key);
+        } else {
+            log.info("Redis unavailable; using DNS fanout for cache invalidation: type={}, key={}", cacheType, key);
+            fanoutToWorkers(cacheType, key);
+        }
+    }
+
+    private void fanoutToWorkers(String cacheType, String key) {
+        if (workerInvalidationConfig == null || !workerInvalidationConfig.isEnabled()
+                || workerInvalidationConfig.getHeadlessServiceHost() == null
+                || workerInvalidationConfig.getHeadlessServiceHost().isBlank()) {
+            throw new IllegalStateException(
+                "Cache invalidation is misconfigured: Redis is disabled and worker fanout is not configured. " +
+                "Enable Redis or set workerInvalidationConfig.headlessServiceHost.");
+        }
+        fanout(workerInvalidationConfig.getHeadlessServiceHost(),
+                workerInvalidationConfig.getAdminPort(),
+                workerInvalidationConfig.getPerPodTimeoutMs(),
+                cacheType, key);
+    }
+
+    private void fanout(String headlessServiceHost, int adminPort, int timeoutMs,
+                        String cacheType, String key) {
+        try {
+            InetAddress[] addresses = InetAddress.getAllByName(headlessServiceHost);
+            log.info("DNS fanout to {} worker pod(s) for cache type={} key={}", addresses.length, cacheType, key);
+            for (InetAddress address : addresses) {
+                postInvalidation(address.getHostAddress(), adminPort, timeoutMs, cacheType, key);
+            }
+        } catch (Exception e) {
+            log.error("Error during DNS fanout to workers for cache type={} key={}", cacheType, key, e);
+            throw new IllegalStateException("DNS fanout failed for cache type=" + cacheType + " key=" + key, e);
+        }
+    }
+
+    private void postInvalidation(String ip, int port, int timeoutMs, String cacheType, String key) {
+        String urlStr = String.format("http://%s:%d/tasks/cache-invalidate?type=%s&key=%s", ip, port,
+                URLEncoder.encode(cacheType, StandardCharsets.UTF_8),
+                URLEncoder.encode(key, StandardCharsets.UTF_8));
+        HttpURLConnection conn = null;
+        try {
+            URL url = new URL(urlStr);
+            conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setConnectTimeout(timeoutMs);
+            conn.setReadTimeout(timeoutMs);
+            conn.setDoOutput(true);
+            int responseCode = conn.getResponseCode();
+            log.debug("Cache invalidation POST to {} returned {}", urlStr, responseCode);
+        } catch (Exception e) {
+            log.error("Failed to POST cache invalidation to {}: {}", urlStr, e.getMessage());
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+    }
+}

--- a/api/src/main/java/com/flipkart/drift/api/config/DriftConfiguration.java
+++ b/api/src/main/java/com/flipkart/drift/api/config/DriftConfiguration.java
@@ -37,5 +37,8 @@ public class DriftConfiguration extends Configuration {
     private String hadoopUserName;
     @NotNull
     private String hadoopLoginUser;
+
+    /** Config for DNS-fanout cache invalidation to worker pods (used when redisEnabled=false). */
+    private WorkerInvalidationConfig workerInvalidationConfig;
 }
 

--- a/api/src/main/java/com/flipkart/drift/api/config/DriftConfiguration.java
+++ b/api/src/main/java/com/flipkart/drift/api/config/DriftConfiguration.java
@@ -8,6 +8,7 @@ import io.dropwizard.Configuration;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 @Getter
@@ -16,6 +17,8 @@ import javax.validation.constraints.NotNull;
 public class DriftConfiguration extends Configuration {
     @NotNull
     private RedisConfiguration redisConfiguration;
+    @Valid
+    private IdempotencyConfig idempotencyConfig;
     @NotNull
     private ExecutorServiceConfig cacheRefreshExecutorServiceConfig;
     @NotNull

--- a/api/src/main/java/com/flipkart/drift/api/config/IdempotencyConfig.java
+++ b/api/src/main/java/com/flipkart/drift/api/config/IdempotencyConfig.java
@@ -1,0 +1,20 @@
+package com.flipkart.drift.api.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * Configuration for business-key idempotency on {@code POST /v3/workflow/start}.
+ */
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class IdempotencyConfig {
+    /** Request header name(s) checked for a client-supplied idempotency key. */
+    private List<String> headers = List.of("X-Drift-Idempotency-Key");
+    /** Whether requests without an idempotency key header are allowed through unchanged. */
+    private boolean optional = true;
+}

--- a/api/src/main/java/com/flipkart/drift/api/config/RedisConfiguration.java
+++ b/api/src/main/java/com/flipkart/drift/api/config/RedisConfiguration.java
@@ -18,6 +18,7 @@ public class RedisConfiguration {
     private int maxWaitMillis;
     private boolean testOnBorrow;
     private boolean blockWhenExhausted;
+    private boolean redisEnabled = true;
     private int database;
 }
 

--- a/api/src/main/java/com/flipkart/drift/api/config/WorkerInvalidationConfig.java
+++ b/api/src/main/java/com/flipkart/drift/api/config/WorkerInvalidationConfig.java
@@ -1,0 +1,25 @@
+package com.flipkart.drift.api.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Configuration for DNS-fanout cache invalidation to worker pods.
+ * Used when Redis pub-sub is unavailable (redisEnabled=false).
+ * Set headlessServiceHost to a K8s headless service DNS name;
+ * InetAddress.getAllByName() will resolve it to all pod IPs.
+ */
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WorkerInvalidationConfig {
+    /** K8s headless service DNS name for workers (resolves to all pod IPs). */
+    private String headlessServiceHost;
+    /** Dropwizard admin port on worker pods (matches adminConnectors port in worker config). */
+    private int adminPort = 5601;
+    /** Per-pod HTTP connect+read timeout in milliseconds. */
+    private int perPodTimeoutMs = 2000;
+    /** Set to false to suppress fanout even when Redis is disabled. */
+    private boolean enabled = true;
+}

--- a/api/src/main/java/com/flipkart/drift/api/filters/IdempotencyFilter.java
+++ b/api/src/main/java/com/flipkart/drift/api/filters/IdempotencyFilter.java
@@ -1,0 +1,63 @@
+package com.flipkart.drift.api.filters;
+
+import com.flipkart.drift.api.service.utils.IdempotencyKeyResolver;
+import com.google.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.ext.Provider;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Resolves the business-key idempotency header on {@code POST /v3/workflow/start} and
+ * stashes the derived workflowId on {@link RequestThreadContext}.
+ * <p>
+ * Request-filter only — there is no response-filter method here; the actual de-dup is
+ * arbitrated server-side by Temporal's atomic {@code StartWorkflowExecution} inside
+ * {@code TemporalService}. This filter never returns a {@code 409}.
+ */
+@Provider
+@Slf4j
+public class IdempotencyFilter implements ContainerRequestFilter {
+
+    private static final Set<String> APPLY_TO_PATHS = Set.of("/v3/workflow/start");
+
+    private final IdempotencyKeyResolver resolver;
+
+    @Inject
+    public IdempotencyFilter(IdempotencyKeyResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        if (!shouldApply(requestContext)) {
+            return;
+        }
+
+        Optional<String> rawKeyOpt = resolver.extractRawKey(requestContext.getHeaders());
+        if (rawKeyOpt.isEmpty()) {
+            // optional=true, no header present -- legacy fall-through, unchanged behavior
+            return;
+        }
+
+        String rawKey = rawKeyOpt.get();
+        RequestThreadContext threadContext = RequestThreadContext.get();
+        String tenant = threadContext.getTenant();
+        String clientId = threadContext.getClientId();
+
+        IdempotencyKey key = resolver.resolve(tenant, clientId, rawKey);
+        threadContext.setResolvedWorkflowId(key.getWorkflowId());
+        threadContext.setIdempotencyKey(rawKey);
+
+        MDC.put("idempotencyKey", rawKey);
+    }
+
+    private boolean shouldApply(ContainerRequestContext requestContext) {
+        String path = "/" + requestContext.getUriInfo().getPath();
+        return APPLY_TO_PATHS.contains(path);
+    }
+}

--- a/api/src/main/java/com/flipkart/drift/api/filters/IdempotencyKey.java
+++ b/api/src/main/java/com/flipkart/drift/api/filters/IdempotencyKey.java
@@ -1,0 +1,17 @@
+package com.flipkart.drift.api.filters;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Value object for a resolved business-key idempotency request. The derived
+ * {@code workflowId} IS the de-dup key, enforced by Temporal itself.
+ */
+@Data
+@Builder
+public class IdempotencyKey {
+    private final String tenant;
+    private final String clientId;
+    private final String rawKey;
+    private final String workflowId;
+}

--- a/api/src/main/java/com/flipkart/drift/api/filters/RequestFilter.java
+++ b/api/src/main/java/com/flipkart/drift/api/filters/RequestFilter.java
@@ -8,6 +8,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.glassfish.jersey.message.internal.ReaderWriter;
 import org.slf4j.MDC;
 
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Response;
@@ -22,6 +24,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Provider
+@Priority(Priorities.AUTHENTICATION)
 @Slf4j
 public class RequestFilter implements ContainerRequestFilter {
     public static final String TENANT_HEADER = "X_TENANT_ID";

--- a/api/src/main/java/com/flipkart/drift/api/filters/RequestThreadContext.java
+++ b/api/src/main/java/com/flipkart/drift/api/filters/RequestThreadContext.java
@@ -12,6 +12,9 @@ public class RequestThreadContext {
     private Boolean perfFlag;
     private String tenant;
     private String username;
+    private String resolvedWorkflowId;
+    private String idempotencyKey;
+    private boolean resolvedFromExistingWorkflow;
 
     public static RequestThreadContext get() {
         return threadLocal.get();
@@ -26,6 +29,9 @@ public class RequestThreadContext {
         tenant = null;
         perfFlag = null;
         username = null;
+        resolvedWorkflowId = null;
+        idempotencyKey = null;
+        resolvedFromExistingWorkflow = false;
     }
 
     public Map<String, String> getLegacyThreadContext() {
@@ -34,6 +40,7 @@ public class RequestThreadContext {
         threadContext.put("userName", username);
         threadContext.put("clientId", clientId);
         threadContext.put("perfFlag", String.valueOf(perfFlag));
+        threadContext.put("idempotencyKey", idempotencyKey);
         return threadContext;
     }
 }

--- a/api/src/main/java/com/flipkart/drift/api/filters/ResponseFilter.java
+++ b/api/src/main/java/com/flipkart/drift/api/filters/ResponseFilter.java
@@ -1,6 +1,7 @@
 package com.flipkart.drift.api.filters;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.MDC;
 
 import javax.ws.rs.container.ContainerRequestContext;
@@ -12,6 +13,9 @@ import javax.ws.rs.ext.Provider;
 @Slf4j
 public class ResponseFilter implements ContainerResponseFilter {
 
+    public static final String WORKFLOW_ID_HEADER = "X-Drift-Workflow-Id";
+    public static final String IDEMPOTENT_REPLAY_HEADER = "X-Drift-Idempotent-Replay";
+
     @Override
     public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext) {
         containerResponseContext.getHeaders().add("Access-Control-Allow-Origin", "*");
@@ -21,11 +25,33 @@ public class ResponseFilter implements ContainerResponseFilter {
             containerResponseContext.getHeaders().add("Access-Control-Allow-Headers", requestHeader);
         }
         containerResponseContext.getHeaders().add("X_SERVER_TRACE_ID", MDC.get("id"));
+        addIdempotencyResponseHeaders(containerResponseContext);
         this.removeFromMDC();
+    }
+
+    /**
+     * Business-key idempotency response headers:
+     * {@code X-Drift-Workflow-Id} is set whenever the request resolved to a business-key
+     * derived workflowId; {@code X-Drift-Idempotent-Replay: true} is added only when that
+     * resolution hit a pre-existing Temporal execution (never {@code "false"} -- omitted
+     * entirely on a genuine fresh start, and omitted entirely for legacy/non-idempotent
+     * requests where {@code resolvedWorkflowId} is blank).
+     */
+    private void addIdempotencyResponseHeaders(ContainerResponseContext containerResponseContext) {
+        RequestThreadContext threadContext = RequestThreadContext.get();
+        String resolvedWorkflowId = threadContext.getResolvedWorkflowId();
+        if (StringUtils.isBlank(resolvedWorkflowId)) {
+            return;
+        }
+        containerResponseContext.getHeaders().add(WORKFLOW_ID_HEADER, resolvedWorkflowId);
+        if (threadContext.isResolvedFromExistingWorkflow()) {
+            containerResponseContext.getHeaders().add(IDEMPOTENT_REPLAY_HEADER, "true");
+        }
     }
 
     private void removeFromMDC() {
         MDC.remove("id");
+        MDC.remove("idempotencyKey");
         RequestThreadContext.remove();
     }
 }

--- a/api/src/main/java/com/flipkart/drift/api/module/WorkflowClientModule.java
+++ b/api/src/main/java/com/flipkart/drift/api/module/WorkflowClientModule.java
@@ -1,6 +1,7 @@
 package com.flipkart.drift.api.module;
 
 import com.codahale.metrics.MetricRegistry;
+import com.flipkart.drift.api.client.CacheInvalidationClient;
 import com.flipkart.drift.api.config.DriftConfiguration;
 import com.flipkart.drift.api.config.IdempotencyConfig;
 import com.flipkart.drift.persistence.dao.ConnectionType;
@@ -10,6 +11,7 @@ import com.flipkart.drift.api.config.RedisConfiguration;
 import com.flipkart.drift.api.exception.mapper.ApiExceptionMapper;
 import com.google.inject.*;
 import com.google.inject.name.Names;
+import javax.annotation.Nullable;
 import com.netflix.config.DynamicProperty;
 import io.dropwizard.setup.Environment;
 import lombok.extern.slf4j.Slf4j;
@@ -44,6 +46,10 @@ public class WorkflowClientModule extends AbstractModule {
     }
 
     private JedisSentinelPool provideJedisPool() {
+        if (!redisConfiguration.isRedisEnabled()) {
+            log.info("Redis is disabled (redisEnabled=false), skipping JedisSentinelPool creation");
+            return null;
+        }
         try {
             final RedisConfiguration redisConfiguration = this.redisConfiguration;
             String hosts = redisConfiguration.getSentinels();
@@ -175,6 +181,7 @@ public class WorkflowClientModule extends AbstractModule {
 
     @Provides
     @Singleton
+    @Nullable
     public JedisSentinelPool getJedisSentinelPool() {
         return this.jedisSentinelPool;
     }
@@ -196,6 +203,12 @@ public class WorkflowClientModule extends AbstractModule {
     @Singleton
     public MetricRegistry getMetricRegistry() {
         return this.metricRegistry;
+    }
+
+    @Provides
+    @Singleton
+    public CacheInvalidationClient getCacheInvalidationClient() {
+        return new CacheInvalidationClient(this.driftConfiguration, this.jedisSentinelPool);
     }
 
 }

--- a/api/src/main/java/com/flipkart/drift/api/module/WorkflowClientModule.java
+++ b/api/src/main/java/com/flipkart/drift/api/module/WorkflowClientModule.java
@@ -2,6 +2,7 @@ package com.flipkart.drift.api.module;
 
 import com.codahale.metrics.MetricRegistry;
 import com.flipkart.drift.api.config.DriftConfiguration;
+import com.flipkart.drift.api.config.IdempotencyConfig;
 import com.flipkart.drift.persistence.dao.ConnectionType;
 import com.flipkart.drift.persistence.dao.IConnectionProvider;
 import com.flipkart.drift.api.exception.JerseyViolationInformativeExceptionMapper;
@@ -31,6 +32,7 @@ public class WorkflowClientModule extends AbstractModule {
     private final JedisSentinelPool jedisSentinelPool;
     private final Environment environment;
     private final DriftConfiguration driftConfiguration;
+    private final MetricRegistry metricRegistry;
 
 
     public WorkflowClientModule(DriftConfiguration driftConfiguration, Environment environment, MetricRegistry metricRegistry) {
@@ -38,6 +40,7 @@ public class WorkflowClientModule extends AbstractModule {
         this.environment = environment;
         this.driftConfiguration = driftConfiguration;
         this.jedisSentinelPool = provideJedisPool();
+        this.metricRegistry = metricRegistry;
     }
 
     private JedisSentinelPool provideJedisPool() {
@@ -180,6 +183,19 @@ public class WorkflowClientModule extends AbstractModule {
     @Singleton
     public DriftConfiguration getDriftConfiguration() {
         return this.driftConfiguration;
+    }
+
+    @Provides
+    @Singleton
+    public IdempotencyConfig getIdempotencyConfig() {
+        IdempotencyConfig config = this.driftConfiguration.getIdempotencyConfig();
+        return config != null ? config : new IdempotencyConfig();
+    }
+
+    @Provides
+    @Singleton
+    public MetricRegistry getMetricRegistry() {
+        return this.metricRegistry;
     }
 
 }

--- a/api/src/main/java/com/flipkart/drift/api/service/RedisPubSubService.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/RedisPubSubService.java
@@ -119,8 +119,15 @@ public class RedisPubSubService implements Managed {
                 try (Timer.Context ignored = timerContext(this.getClass(), action, "latency")) {
                     onSubscribeAction.call();
                 } catch (Exception e) {
-                    markMeter(this.getClass(), "onSubscribeAction", "exception");
-                    log.error("Exception during onSubscribe action for channel: {}", channel, e);
+                    if (e instanceof io.temporal.client.WorkflowException) {
+                        // WorkflowException (incl. WorkflowExecutionAlreadyStarted) is a routine
+                        // signal on idempotent duplicate starts — propagate without ERROR noise or
+                        // generic exception-meter increment; TemporalService resolves it upstream.
+                        log.debug("WorkflowException in onSubscribe for channel: {} — {}", channel, e.getMessage());
+                    } else {
+                        markMeter(this.getClass(), "onSubscribeAction", "exception");
+                        log.error("Exception during onSubscribe action for channel: {}", channel, e);
+                    }
                     safeUnsubscribe(this, "onSubscribeAction error", channel);
                     redisFuture.completeExceptionally(e);
                 }
@@ -162,6 +169,13 @@ public class RedisPubSubService implements Managed {
             Throwable cause = e.getCause();
             if (cause instanceof io.temporal.client.WorkflowNotFoundException) {
                 throw (io.temporal.client.WorkflowNotFoundException) cause;
+            }
+            // Business-key idempotency: WorkflowExecutionAlreadyStarted (and any other
+            // WorkflowException) must propagate unwrapped so TemporalService.executeWorkflow's
+            // catch blocks -- not this generic error path -- resolve the duplicate. Without this,
+            // the already-started signal is swallowed into a generic 500 by logAndMarkMeter below.
+            if (cause instanceof io.temporal.client.WorkflowException) {
+                throw (io.temporal.client.WorkflowException) cause;
             }
             logAndMarkMeter(channelName, e);
         }

--- a/api/src/main/java/com/flipkart/drift/api/service/RedisPubSubService.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/RedisPubSubService.java
@@ -5,6 +5,7 @@ import com.codahale.metrics.Timer;
 import com.flipkart.drift.api.exception.ApiException;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import javax.annotation.Nullable;
 import io.dropwizard.lifecycle.Managed;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -27,7 +28,7 @@ public class RedisPubSubService implements Managed {
     private final ExecutorService redisThreadPool;
 
     @Inject
-    public RedisPubSubService(JedisSentinelPool jedisSentinelPool) {
+    public RedisPubSubService(@Nullable JedisSentinelPool jedisSentinelPool) {
         this.jedisSentinelPool = jedisSentinelPool;
         this.redisThreadPool = new ThreadPoolExecutor(
                 10, 50,
@@ -39,6 +40,10 @@ public class RedisPubSubService implements Managed {
     }
 
     private void publishGaugeMetrics() {
+        if (jedisSentinelPool == null) {
+            log.info("Redis pool is null (Redis disabled), skipping Jedis gauge registration");
+            return;
+        }
         // Monitor jedis pool metrics
         registerGauge(
                 this.getClass(),

--- a/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
@@ -1,6 +1,7 @@
 package com.flipkart.drift.api.service;
 
 import com.flipkart.drift.api.config.DriftConfiguration;
+import com.flipkart.drift.api.config.RedisConfiguration;
 import com.flipkart.drift.api.filters.RequestThreadContext;
 import com.flipkart.drift.api.exception.ApiException;
 import com.flipkart.drift.sdk.model.enums.WorkflowExecutionMode;
@@ -114,7 +115,8 @@ public class TemporalService {
                         .build();
             } else {
                 // SYNC mode: block until workflow reaches a terminal state via Redis
-                if (!driftConfiguration.getRedisConfiguration().isRedisEnabled()) {
+                RedisConfiguration redisConfiguration = driftConfiguration.getRedisConfiguration();
+                if (redisConfiguration == null || !redisConfiguration.isRedisEnabled()) {
                     throw new ApiException(Response.Status.BAD_REQUEST,
                             "SYNC execution mode requires Redis to be enabled. " +
                             "Set executionMode=ASYNC or enable Redis (redisEnabled=true).");
@@ -194,7 +196,8 @@ public class TemporalService {
                 workflow.resumeWorkflow(workflowResumeRequest);
                 return buildResponseAndReturn(workflow);
             } else {
-                if (!driftConfiguration.getRedisConfiguration().isRedisEnabled()) {
+                RedisConfiguration redisConfiguration = driftConfiguration.getRedisConfiguration();
+                if (redisConfiguration == null || !redisConfiguration.isRedisEnabled()) {
                     throw new ApiException(Response.Status.BAD_REQUEST,
                             "SYNC execution mode requires Redis to be enabled. " +
                             "Set executionMode=ASYNC or enable Redis (redisEnabled=true).");

--- a/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
@@ -3,6 +3,7 @@ package com.flipkart.drift.api.service;
 import com.flipkart.drift.api.config.DriftConfiguration;
 import com.flipkart.drift.api.filters.RequestThreadContext;
 import com.flipkart.drift.api.exception.ApiException;
+import com.flipkart.drift.sdk.model.enums.WorkflowExecutionMode;
 import com.flipkart.drift.api.service.idempotency.IdempotencyMetrics;
 import com.flipkart.drift.sdk.model.request.WorkflowResumeRequest;
 import com.flipkart.drift.sdk.model.request.WorkflowStartRequest;
@@ -11,6 +12,7 @@ import com.flipkart.drift.sdk.model.request.WorkflowUtilityRequest;
 import com.flipkart.drift.sdk.model.response.View;
 import com.flipkart.drift.sdk.model.response.WorkflowResponse;
 import com.flipkart.drift.sdk.model.response.WorkflowUtilityResponse;
+import com.flipkart.drift.sdk.model.enums.WorkflowStatus;
 import com.flipkart.drift.commons.model.temporal.WorkflowState;
 import com.flipkart.drift.api.service.utils.Utility;
 import com.flipkart.drift.workflows.GenericWorkflow;
@@ -85,6 +87,10 @@ public class TemporalService {
         WorkflowIdReusePolicy reusePolicy = idempotent
                 ? WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY
                 : WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING;
+        WorkflowExecutionMode executionMode = workflowStartRequest.getWorkflowExecutionMode() != null
+                ? workflowStartRequest.getWorkflowExecutionMode()
+                : WorkflowExecutionMode.SYNC;
+
         GenericWorkflow workflow;
         try {
             workflow = client.newWorkflowStub(
@@ -96,19 +102,39 @@ public class TemporalService {
                             .setWorkflowIdReusePolicy(reusePolicy)
                             .build()
             );
-            redisPubSubService.subscribeAndExecute(workflowId, () -> {
+
+            if (executionMode == WorkflowExecutionMode.ASYNC) {
                 WorkflowClient.start(workflow::startWorkflow, workflowStartRequest);
-                return null;
-            }, START);
-            if (idempotent) {
-                idempotencyMetrics.miss(RequestThreadContext.get().getTenant(), RequestThreadContext.get().getClientId());
+                if (idempotent) {
+                    idempotencyMetrics.miss(RequestThreadContext.get().getTenant(), RequestThreadContext.get().getClientId());
+                }
+                return WorkflowResponse.builder()
+                        .workflowId(workflowId)
+                        .workflowStatus(WorkflowStatus.RUNNING)
+                        .build();
+            } else {
+                // SYNC mode: block until workflow reaches a terminal state via Redis
+                if (!driftConfiguration.getRedisConfiguration().isRedisEnabled()) {
+                    throw new ApiException(Response.Status.BAD_REQUEST,
+                            "SYNC execution mode requires Redis to be enabled. " +
+                            "Set executionMode=ASYNC or enable Redis (redisEnabled=true).");
+                }
+                redisPubSubService.subscribeAndExecute(workflowId, () -> {
+                    WorkflowClient.start(workflow::startWorkflow, workflowStartRequest);
+                    return null;
+                }, START);
+                if (idempotent) {
+                    idempotencyMetrics.miss(RequestThreadContext.get().getTenant(), RequestThreadContext.get().getClientId());
+                }
+                return buildResponseAndReturn(workflow);
             }
-            return buildResponseAndReturn(workflow);
         } catch (WorkflowExecutionAlreadyStarted e) {
             // Most-specific-exception-first: WorkflowExecutionAlreadyStarted extends
             // WorkflowException, so this catch MUST precede catch(WorkflowException) below,
             // otherwise it is unreachable dead code.
             return resolveAlreadyStartedWorkflow(workflowStartRequest, allowPurgeRetry);
+        } catch (ApiException e) {
+            throw e;
         } catch (WorkflowNotFoundException e) {
             throw new ApiException(Response.Status.NOT_FOUND, e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
         } catch (WorkflowException e) {
@@ -157,11 +183,30 @@ public class TemporalService {
         try {
             workflowResumeRequest.setThreadContext(RequestThreadContext.get().getLegacyThreadContext());
             GenericWorkflow workflow = client.newWorkflowStub(GenericWorkflow.class, workflowResumeRequest.getWorkflowId());
-            redisPubSubService.subscribeAndExecute(workflowResumeRequest.getWorkflowId(), () -> {
+
+            // Determine execution mode from the running workflow's persisted state
+            WorkflowState currentState = workflow.getWorkflowState();
+            WorkflowExecutionMode executionMode = currentState.getWorkflowExecutionMode() != null
+                    ? currentState.getWorkflowExecutionMode()
+                    : WorkflowExecutionMode.SYNC;
+
+            if (executionMode == WorkflowExecutionMode.ASYNC) {
                 workflow.resumeWorkflow(workflowResumeRequest);
-                return null;
-            }, RESUME);
-            return buildResponseAndReturn(workflow);
+                return buildResponseAndReturn(workflow);
+            } else {
+                if (!driftConfiguration.getRedisConfiguration().isRedisEnabled()) {
+                    throw new ApiException(Response.Status.BAD_REQUEST,
+                            "SYNC execution mode requires Redis to be enabled. " +
+                            "Set executionMode=ASYNC or enable Redis (redisEnabled=true).");
+                }
+                redisPubSubService.subscribeAndExecute(workflowResumeRequest.getWorkflowId(), () -> {
+                    workflow.resumeWorkflow(workflowResumeRequest);
+                    return null;
+                }, RESUME);
+                return buildResponseAndReturn(workflow);
+            }
+        } catch (ApiException e) {
+            throw e;
         } catch (WorkflowNotFoundException e) {
             throw new ApiException(Response.Status.NOT_FOUND, e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
         } catch (WorkflowException e) {
@@ -224,7 +269,3 @@ public class TemporalService {
                 .build();
     }
 }
-
-
-
-

--- a/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
@@ -1,6 +1,7 @@
 package com.flipkart.drift.api.service;
 
 import com.flipkart.drift.api.config.DriftConfiguration;
+import com.flipkart.drift.api.config.RedisConfiguration;
 import com.flipkart.drift.api.filters.RequestThreadContext;
 import com.flipkart.drift.api.exception.ApiException;
 import com.flipkart.drift.sdk.model.enums.WorkflowExecutionMode;
@@ -114,7 +115,8 @@ public class TemporalService {
                         .build();
             } else {
                 // SYNC mode: block until workflow reaches a terminal state via Redis
-                if (!driftConfiguration.getRedisConfiguration().isRedisEnabled()) {
+                RedisConfiguration redisConfiguration = driftConfiguration.getRedisConfiguration();
+                if (redisConfiguration != null && !redisConfiguration.isRedisEnabled()) {
                     throw new ApiException(Response.Status.BAD_REQUEST,
                             "SYNC execution mode requires Redis to be enabled. " +
                             "Set executionMode=ASYNC or enable Redis (redisEnabled=true).");
@@ -194,7 +196,8 @@ public class TemporalService {
                 workflow.resumeWorkflow(workflowResumeRequest);
                 return buildResponseAndReturn(workflow);
             } else {
-                if (!driftConfiguration.getRedisConfiguration().isRedisEnabled()) {
+                RedisConfiguration redisConfiguration = driftConfiguration.getRedisConfiguration();
+                if (redisConfiguration != null && !redisConfiguration.isRedisEnabled()) {
                     throw new ApiException(Response.Status.BAD_REQUEST,
                             "SYNC execution mode requires Redis to be enabled. " +
                             "Set executionMode=ASYNC or enable Redis (redisEnabled=true).");

--- a/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
@@ -3,6 +3,7 @@ package com.flipkart.drift.api.service;
 import com.flipkart.drift.api.config.DriftConfiguration;
 import com.flipkart.drift.api.filters.RequestThreadContext;
 import com.flipkart.drift.api.exception.ApiException;
+import com.flipkart.drift.api.service.idempotency.IdempotencyMetrics;
 import com.flipkart.drift.sdk.model.request.WorkflowResumeRequest;
 import com.flipkart.drift.sdk.model.request.WorkflowStartRequest;
 import com.flipkart.drift.sdk.model.request.WorkflowTerminateRequest;
@@ -19,6 +20,7 @@ import io.temporal.client.*;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.ws.rs.core.Response;
 import java.time.Duration;
@@ -37,11 +39,13 @@ public class TemporalService {
     public static final String RESUME = "resume";
     private final Utility utility;
     private final DriftConfiguration driftConfiguration;
+    private final IdempotencyMetrics idempotencyMetrics;
 
     @Inject
     public TemporalService(RedisPubSubService redisPubSubService,
                            DriftConfiguration driftConfiguration,
-                           Utility utility) {
+                           Utility utility,
+                           IdempotencyMetrics idempotencyMetrics) {
         this.stubsOptions = WorkflowServiceStubsOptions
                 .newBuilder()
                 .setTarget(driftConfiguration.getTemporalFrontEnd())
@@ -51,10 +55,14 @@ public class TemporalService {
         this.client = WorkflowClient.newInstance(serviceStub);
         this.utility = utility;
         this.driftConfiguration = driftConfiguration;
+        this.idempotencyMetrics = idempotencyMetrics;
     }
 
     public WorkflowResponse startWorkflow(WorkflowStartRequest workflowStartRequest) {
-        if (workflowStartRequest.getWorkflowId() == null || workflowStartRequest.getWorkflowId().isBlank()) {
+        String resolvedWorkflowId = RequestThreadContext.get().getResolvedWorkflowId();
+        if (StringUtils.isNotBlank(resolvedWorkflowId)) {
+            workflowStartRequest.setWorkflowId(resolvedWorkflowId);
+        } else if (workflowStartRequest.getWorkflowId() == null || workflowStartRequest.getWorkflowId().isBlank()) {
             workflowStartRequest.setWorkflowId(utility.generateWorkflowId(null, false));
         }
         workflowStartRequest.setThreadContext(RequestThreadContext.get().getLegacyThreadContext());
@@ -62,7 +70,21 @@ public class TemporalService {
     }
 
     public WorkflowResponse executeWorkflow(WorkflowStartRequest workflowStartRequest) {
+        return executeWorkflow(workflowStartRequest, true);
+    }
+
+    /**
+     * @param allowPurgeRetry whether an already-started-but-history-purged race should
+     *                        be resolved by retrying the start once as a fresh workflow. Set to
+     *                        {@code false} on the retry attempt itself to guarantee termination
+     *                        (at most one retry per request, never unbounded recursion).
+     */
+    private WorkflowResponse executeWorkflow(WorkflowStartRequest workflowStartRequest, boolean allowPurgeRetry) {
         String workflowId = workflowStartRequest.getWorkflowId();
+        boolean idempotent = StringUtils.isNotBlank(RequestThreadContext.get().getResolvedWorkflowId());
+        WorkflowIdReusePolicy reusePolicy = idempotent
+                ? WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY
+                : WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING;
         GenericWorkflow workflow;
         try {
             workflow = client.newWorkflowStub(
@@ -71,14 +93,22 @@ public class TemporalService {
                             .setWorkflowId(workflowId)
                             .setWorkflowExecutionTimeout(Duration.ofMinutes(1440))
                             .setTaskQueue(driftConfiguration.getTemporalTaskQueue())
-                            .setWorkflowIdReusePolicy(WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING)
+                            .setWorkflowIdReusePolicy(reusePolicy)
                             .build()
             );
             redisPubSubService.subscribeAndExecute(workflowId, () -> {
                 WorkflowClient.start(workflow::startWorkflow, workflowStartRequest);
                 return null;
             }, START);
+            if (idempotent) {
+                idempotencyMetrics.miss(RequestThreadContext.get().getTenant(), RequestThreadContext.get().getClientId());
+            }
             return buildResponseAndReturn(workflow);
+        } catch (WorkflowExecutionAlreadyStarted e) {
+            // Most-specific-exception-first: WorkflowExecutionAlreadyStarted extends
+            // WorkflowException, so this catch MUST precede catch(WorkflowException) below,
+            // otherwise it is unreachable dead code.
+            return resolveAlreadyStartedWorkflow(workflowStartRequest, allowPurgeRetry);
         } catch (WorkflowNotFoundException e) {
             throw new ApiException(Response.Status.NOT_FOUND, e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
         } catch (WorkflowException e) {
@@ -87,6 +117,39 @@ public class TemporalService {
         } catch (Exception e) {
             log.error("Unexpected error during workflow start: {}", e.getMessage(), e);
             throw new ApiException(Response.Status.INTERNAL_SERVER_ERROR, "Failed to start workflow: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Resolves a duplicate start signaled by Temporal via {@code WorkflowExecutionAlreadyStarted}
+     * (the primary, server-arbitrated de-dup mechanism). Fetches and returns the existing
+     * workflow's state, marking the request as an idempotent replay. Handles the narrow
+     * history-purged race: if the existing workflow's state can no longer be queried
+     * because Temporal namespace retention has purged its history, meters that fact and retries
+     * the start once as a fresh workflow rather than surfacing a 502.
+     */
+    private WorkflowResponse resolveAlreadyStartedWorkflow(WorkflowStartRequest workflowStartRequest,
+                                                            boolean allowPurgeRetry) {
+        String workflowId = workflowStartRequest.getWorkflowId();
+        String tenant = RequestThreadContext.get().getTenant();
+        String clientId = RequestThreadContext.get().getClientId();
+        log.info("Workflow already started for idempotent wfId={}", workflowId);
+        idempotencyMetrics.alreadyStarted(tenant, clientId);
+        try {
+            GenericWorkflow existing = client.newWorkflowStub(GenericWorkflow.class, workflowId);
+            WorkflowResponse response = buildResponseAndReturn(existing);
+            RequestThreadContext.get().setResolvedFromExistingWorkflow(true);
+            return response;
+        } catch (WorkflowNotFoundException | WorkflowQueryException notFound) {
+            // History-purged edge case: the existing execution's history is gone by the time we
+            // query it. Not an error the caller should see -- meter it and treat the request as
+            // a fresh start (Temporal no longer has state under this workflowId to conflict with).
+            idempotencyMetrics.historyPurged(tenant, clientId);
+            if (!allowPurgeRetry) {
+                throw new ApiException(Response.Status.INTERNAL_SERVER_ERROR,
+                        "Workflow " + workflowId + " could not be started or resolved after history-purge retry");
+            }
+            return executeWorkflow(workflowStartRequest, false);
         }
     }
 

--- a/api/src/main/java/com/flipkart/drift/api/service/builder/NodeDefinitionService.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/builder/NodeDefinitionService.java
@@ -1,6 +1,7 @@
 package com.flipkart.drift.api.service.builder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flipkart.drift.api.client.CacheInvalidationClient;
 import com.flipkart.drift.persistence.dao.ConnectionType;
 import com.flipkart.drift.persistence.dao.NodeDefinitionDao;
 import com.flipkart.drift.persistence.entity.NodeHB;
@@ -8,26 +9,22 @@ import com.flipkart.drift.commons.exception.ApiException;
 import com.flipkart.drift.commons.model.enums.Version;
 import com.flipkart.drift.commons.model.node.NodeDefinition;
 import com.google.inject.Inject;
-import redis.clients.jedis.JedisSentinelPool;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 
 import static com.flipkart.drift.commons.utils.Utility.*;
 
-import static com.flipkart.drift.api.service.utils.Utility.publishRedisEvent;
-import static com.flipkart.drift.commons.utils.Constants.Workflow.DSL_UPDATE_CHANNEL;
-
 public class NodeDefinitionService {
     public static final String NODE_EVENT_ID = "NODE";
     private final NodeDefinitionDao nodeDefinitionDao;
-    private final JedisSentinelPool jedisSentinelPool;
+    private final CacheInvalidationClient cacheInvalidationClient;
 
     @Inject
     public NodeDefinitionService(NodeDefinitionDao nodeDefinitionDao, ObjectMapper objectMapper,
-                                 JedisSentinelPool jedisSentinelPool) {
+                                 CacheInvalidationClient cacheInvalidationClient) {
         this.nodeDefinitionDao = nodeDefinitionDao;
-        this.jedisSentinelPool = jedisSentinelPool;
+        this.cacheInvalidationClient = cacheInvalidationClient;
     }
 
     public NodeDefinition addNode(NodeDefinition wfNodeData) {
@@ -81,8 +78,8 @@ public class NodeDefinitionService {
                 String versionKey = generateRowKey(id, version);
                 createNode(versionKey, nodeDefinition); // ABC_1
 
-                publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, NODE_EVENT_ID + " " + versionKey);
-                publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, NODE_EVENT_ID + " " + latestKey);
+                cacheInvalidationClient.invalidate(NODE_EVENT_ID, versionKey);
+                cacheInvalidationClient.invalidate(NODE_EVENT_ID, latestKey);
 
                 return;
             }
@@ -95,8 +92,8 @@ public class NodeDefinitionService {
             createNode(versionKey, nodeDefinition); //ABC_2, ABC_3
 
             updateNodeInHBase(generateRowKey(id, Version.LATEST), nodeDefinition);//Update of latest
-            publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, NODE_EVENT_ID + " " + versionKey);
-            publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, NODE_EVENT_ID + " " + latestKey);
+            cacheInvalidationClient.invalidate(NODE_EVENT_ID, versionKey);
+            cacheInvalidationClient.invalidate(NODE_EVENT_ID, latestKey);
 
 
         } catch (Exception e) {

--- a/api/src/main/java/com/flipkart/drift/api/service/builder/WorkflowDefinitionService.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/builder/WorkflowDefinitionService.java
@@ -2,6 +2,7 @@ package com.flipkart.drift.api.service.builder;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flipkart.drift.api.client.CacheInvalidationClient;
 import com.flipkart.drift.api.service.utils.WorkflowGraphNode;
 import com.flipkart.drift.commons.exception.ApiException;
 import com.flipkart.drift.commons.model.enums.NodeType;
@@ -23,9 +24,7 @@ import guru.nidi.graphviz.engine.GraphvizJdkEngine;
 import guru.nidi.graphviz.model.Graph;
 import guru.nidi.graphviz.model.Node;
 import lombok.extern.slf4j.Slf4j;
-import redis.clients.jedis.JedisSentinelPool;
 
-import static com.flipkart.drift.api.service.utils.Utility.publishRedisEvent;
 import static guru.nidi.graphviz.model.Factory.graph;
 import static guru.nidi.graphviz.model.Factory.node;
 import static guru.nidi.graphviz.model.Link.to;
@@ -36,7 +35,6 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.flipkart.drift.commons.utils.Constants.Workflow.DSL_UPDATE_CHANNEL;
 import static com.flipkart.drift.commons.utils.Utility.*;
 
 @Slf4j
@@ -44,16 +42,16 @@ public class WorkflowDefinitionService {
 
     public static final String WORKFLOW_EVENT_ID = "WORKFLOW";
     private final WorkflowDefinitionDao workflowDefinitionDao;
-    private final JedisSentinelPool jedisSentinelPool;
+    private final CacheInvalidationClient cacheInvalidationClient;
     private final NodeDefinitionService nodeDefinitionService;
 
 
     @Inject
     public WorkflowDefinitionService(WorkflowDefinitionDao workflowDefinitionDao, ObjectMapper objectMapper,
-                                     JedisSentinelPool jedisSentinelPool,
+                                     CacheInvalidationClient cacheInvalidationClient,
                                      NodeDefinitionService nodeDefinitionService) {
         this.workflowDefinitionDao = workflowDefinitionDao;
-        this.jedisSentinelPool = jedisSentinelPool;
+        this.cacheInvalidationClient = cacheInvalidationClient;
         this.nodeDefinitionService = nodeDefinitionService;
     }
 
@@ -240,8 +238,8 @@ public class WorkflowDefinitionService {
 
                 String versionKey = generateRowKey(id, version);
                 createWorkflow(versionKey, workflow); // ABC_1
-                publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, WORKFLOW_EVENT_ID + " " + versionKey);
-                publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, WORKFLOW_EVENT_ID + " " + latestKey);
+                cacheInvalidationClient.invalidate(WORKFLOW_EVENT_ID, versionKey);
+                cacheInvalidationClient.invalidate(WORKFLOW_EVENT_ID, latestKey);
 
                 return;
             }
@@ -254,8 +252,8 @@ public class WorkflowDefinitionService {
             createWorkflow(versionKey, workflow); // ABC_2 abc_3
 
             updateWorkflowInHBase(latestKey, workflow); //ABC_LATEST->Data of ABC_2 abc3
-            publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, WORKFLOW_EVENT_ID + " " + versionKey);
-            publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, WORKFLOW_EVENT_ID + " " + latestKey);
+            cacheInvalidationClient.invalidate(WORKFLOW_EVENT_ID, versionKey);
+            cacheInvalidationClient.invalidate(WORKFLOW_EVENT_ID, latestKey);
 
         } catch (Exception e) {
             throw new ApiException("Error while publishing workflow in HBase", Response.Status.INTERNAL_SERVER_ERROR, e);
@@ -315,7 +313,7 @@ public class WorkflowDefinitionService {
 
         String activeKey = generateRowKey(id, Version.ACTIVE);
         createWorkflow(activeKey, workflow);
-        publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, WORKFLOW_EVENT_ID + " " + activeKey);
+        cacheInvalidationClient.invalidate(WORKFLOW_EVENT_ID, activeKey);
 
     }
 

--- a/api/src/main/java/com/flipkart/drift/api/service/idempotency/IdempotencyMetrics.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/idempotency/IdempotencyMetrics.java
@@ -1,0 +1,49 @@
+package com.flipkart.drift.api.service.idempotency;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import java.util.Locale;
+
+/**
+ * Codahale meters for the business-key idempotency feature: {@code miss} (a fresh workflow
+ * start), {@code already_started} (Temporal detected a duplicate start), and
+ * {@code history_purged} (the duplicate's history was no longer queryable, so a retry
+ * was attempted).
+ *
+ * <p>Metric names are structured as {@code <base>.<tenant>.<clientId>} so Grafana can slice
+ * by tenant ({@code drift.idempotency.miss.<tenant>.*}) or by client
+ * ({@code drift.idempotency.miss.*.<clientId>}) using wildcard queries.
+ */
+@Singleton
+public class IdempotencyMetrics {
+
+    static final String MISS              = "drift.idempotency.miss";
+    static final String ALREADY_STARTED   = "drift.idempotency.temporal.already_started";
+    static final String HISTORY_PURGED    = "drift.idempotency.temporal.history_purged";
+
+    private final MetricRegistry metricRegistry;
+
+    @Inject
+    public IdempotencyMetrics(MetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
+    }
+
+    public void miss(String tenant, String clientId) {
+        meter(MISS, tenant, clientId).mark();
+    }
+
+    public void alreadyStarted(String tenant, String clientId) {
+        meter(ALREADY_STARTED, tenant, clientId).mark();
+    }
+
+    public void historyPurged(String tenant, String clientId) {
+        meter(HISTORY_PURGED, tenant, clientId).mark();
+    }
+
+    private Meter meter(String base, String tenant, String clientId) {
+        return metricRegistry.meter(base + "." + tenant.toLowerCase(Locale.ROOT) + "." + clientId.toLowerCase(Locale.ROOT));
+    }
+}

--- a/api/src/main/java/com/flipkart/drift/api/service/utils/IdempotencyKeyResolver.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/utils/IdempotencyKeyResolver.java
@@ -1,0 +1,101 @@
+package com.flipkart.drift.api.service.utils;
+
+import com.flipkart.drift.api.config.IdempotencyConfig;
+import com.flipkart.drift.api.exception.ApiException;
+import com.flipkart.drift.api.filters.IdempotencyKey;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Resolves the business-key idempotency header on {@code POST /v3/workflow/start}
+ * into a raw key and, from there, a deterministic Temporal workflowId, isolated by
+ * tenant and clientId via a SHA-256-derived workflowId.
+ */
+@Slf4j
+@Singleton
+public class IdempotencyKeyResolver {
+
+    private static final String WORKFLOW_ID_PREFIX = "WF-";
+    private static final Pattern VALID_KEY_PATTERN = Pattern.compile("[A-Za-z0-9_\\-:.]{1,256}");
+
+    public static final String ERROR_MISSING = "IDEMPOTENCY_KEY_MISSING";
+    public static final String ERROR_AMBIGUOUS = "IDEMPOTENCY_KEY_AMBIGUOUS";
+    public static final String ERROR_MALFORMED = "IDEMPOTENCY_KEY_MALFORMED";
+
+    private final IdempotencyConfig idempotencyConfig;
+
+    @Inject
+    public IdempotencyKeyResolver(IdempotencyConfig idempotencyConfig) {
+        this.idempotencyConfig = idempotencyConfig;
+    }
+
+    /**
+     * Extracts and validates the raw idempotency key from the configured header(s).
+     *
+     * @return {@code Optional.empty()} only when no configured header is present and
+     * {@code idempotencyConfig.isOptional()} is true (legacy fall-through path).
+     */
+    public Optional<String> extractRawKey(MultivaluedMap<String, String> headers) {
+        Set<String> distinctValues = new LinkedHashSet<>();
+        for (String headerName : idempotencyConfig.getHeaders()) {
+            String value = headers.getFirst(headerName);
+            if (value != null && !value.isBlank()) {
+                distinctValues.add(value);
+            }
+        }
+
+        if (distinctValues.isEmpty()) {
+            if (idempotencyConfig.isOptional()) {
+                return Optional.empty();
+            }
+            throw new ApiException(Response.Status.BAD_REQUEST,
+                    "Idempotency key header is required but was not supplied", ERROR_MISSING);
+        }
+
+        if (distinctValues.size() > 1) {
+            throw new ApiException(Response.Status.BAD_REQUEST,
+                    "Multiple idempotency key headers supplied with conflicting values", ERROR_AMBIGUOUS);
+        }
+
+        String rawKey = distinctValues.iterator().next();
+        if (!VALID_KEY_PATTERN.matcher(rawKey).matches()) {
+            throw new ApiException(Response.Status.BAD_REQUEST,
+                    "Idempotency key does not match required format [A-Za-z0-9_\\-:.]{1,256}", ERROR_MALFORMED);
+        }
+
+        return Optional.of(rawKey);
+    }
+
+    /**
+     * Derives a deterministic Temporal workflowId from tenant + clientId + rawKey.
+     * All three components are bound into the SHA-256 input using a NUL-byte separator
+     * (U+0000 cannot appear in HTTP header values or the allowed rawKey charset), so the
+     * hash is unique per (tenant, clientId, rawKey) triple even when the lowercased
+     * "{tenant}-{clientId}" prefix looks identical across different splits
+     * (e.g. tenant="a", clientId="b-c" vs tenant="a-b", clientId="c").
+     */
+    public String toWorkflowId(String tenant, String clientId, String rawKey) {
+        String t = tenant.toLowerCase();
+        String c = clientId.toLowerCase();
+        String hashInput = t + "\0" + c + "\0" + rawKey;
+        return WORKFLOW_ID_PREFIX + t + "-" + c + "-" + DigestUtils.sha256Hex(hashInput);
+    }
+
+    public IdempotencyKey resolve(String tenant, String clientId, String rawKey) {
+        return IdempotencyKey.builder()
+                .tenant(tenant)
+                .clientId(clientId)
+                .rawKey(rawKey)
+                .workflowId(toWorkflowId(tenant, clientId, rawKey))
+                .build();
+    }
+}

--- a/api/src/main/resources/config/configuration.yaml
+++ b/api/src/main/resources/config/configuration.yaml
@@ -15,7 +15,13 @@ logging:
     - type: console
       threshold: ALL
       timeZone: IST
-      logFormat: "%date %level [%thread] %logger{0} [%X{id}] %msg%n"
+      logFormat: "%date %level [%thread] %logger{0} [%X{id}][%X{idempotencyKey}] %msg%n"
+
+idempotencyConfig:
+  # Request header name(s) checked for a client-supplied idempotency key.
+  headers: [${IDEMPOTENCY_HEADERS:-X-Drift-Idempotency-Key}]
+  # Whether requests without an idempotency key header are allowed through unchanged.
+  optional: ${IDEMPOTENCY_OPTIONAL:-true}
 
 redisConfiguration:
   password: ${REDIS_PASSWORD}

--- a/api/src/main/resources/config/configuration.yaml
+++ b/api/src/main/resources/config/configuration.yaml
@@ -35,6 +35,7 @@ redisConfiguration:
   minIdle: 25
   testOnBorrow: true
   blockWhenExhausted: true
+  redisEnabled: ${REDIS_ENABLED:true}  # override via env var; defaults to true for backward compatibility
 
 cacheRefreshExecutorServiceConfig:
   minThreads: 1
@@ -54,7 +55,7 @@ hbaseNamespaceConfig:
   cold: ${HBASE_NAMESPACE_COLD:-ims_cold}
   archival: ${HBASE_NAMESPACE_ARCHIVAL:-ims_archive}
   audit: ${HBASE_NAMESPACE_AUDIT:-ims_audit}
-  
+
 hbasePropertiesPath: ${HBASE_CONFIG_BUCKET}
 
 temporalFrontEnd: ${TEMPORAL_FRONTEND}
@@ -64,3 +65,12 @@ temporalTaskQueue: ${TEMPORAL_TASK_QUEUE}
 hadoopUserName: ${HADOOP_USERNAME}
 
 hadoopLoginUser: ${HADOOP_LOGIN_USER}
+
+# DNS-fanout cache invalidation (used when redisEnabled=false).
+# Set headlessServiceHost to the K8s headless service DNS name for worker pods so that
+# InetAddress.getAllByName() resolves to all pod IPs.
+workerInvalidationConfig:
+  headlessServiceHost: ${WORKER_HEADLESS_HOST:}
+  adminPort: ${WORKER_ADMIN_PORT:7201}
+  perPodTimeoutMs: 2000
+  enabled: true

--- a/api/src/test/java/com/flipkart/drift/api/filters/IdempotencyFilterTest.java
+++ b/api/src/test/java/com/flipkart/drift/api/filters/IdempotencyFilterTest.java
@@ -1,0 +1,145 @@
+package com.flipkart.drift.api.filters;
+
+import com.flipkart.drift.api.config.IdempotencyConfig;
+import com.flipkart.drift.api.exception.ApiException;
+import com.flipkart.drift.api.service.utils.IdempotencyKeyResolver;
+import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Direct unit test invoking {@link IdempotencyFilter#filter} with a mocked
+ * {@link ContainerRequestContext}/{@link UriInfo} rather than a live Jersey test
+ * container -- this repo has no {@code jersey-test-framework} dependency wired anywhere
+ * (verified: only {@code dropwizard-core}, no test-container artifact in any pom.xml),
+ * so introducing one purely for this filter would be a disproportionate blast-radius
+ * increase for a request filter whose only external touch points (JAX-RS context
+ * interfaces) are already trivially mockable. {@code ContainerRequestContext}/{@code UriInfo}
+ * are framework-provided value carriers, not internal classes we own, so mocking them here
+ * still satisfies TEST.md's "mock only at system boundaries" rule.
+ */
+class IdempotencyFilterTest {
+
+    private static final String HEADER = "X-Drift-Idempotency-Key";
+
+    private IdempotencyFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        RequestThreadContext.get().clear();
+        IdempotencyConfig config = new IdempotencyConfig();
+        config.setHeaders(List.of(HEADER));
+        config.setOptional(true);
+        IdempotencyKeyResolver resolver = new IdempotencyKeyResolver(config);
+        filter = new IdempotencyFilter(resolver);
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestThreadContext.remove();
+    }
+
+    private ContainerRequestContext contextFor(String path, String headerValue) {
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(uriInfo.getPath()).thenReturn(path);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        MultivaluedMap<String, String> headers = new MultivaluedStringMap();
+        if (headerValue != null) {
+            headers.add(HEADER, headerValue);
+        }
+        when(ctx.getHeaders()).thenReturn(headers);
+        return ctx;
+    }
+
+    @Test
+    void firstRequestResolvesWorkflowIdOnThreadContext() {
+        RequestThreadContext.get().setTenant("tenant1");
+        RequestThreadContext.get().setClientId("client1");
+
+        filter.filter(contextFor("v3/workflow/start", "order-123"));
+
+        assertEquals("order-123", RequestThreadContext.get().getIdempotencyKey());
+        assertTrue(RequestThreadContext.get().getResolvedWorkflowId().startsWith("WF-tenant1-client1-"));
+    }
+
+    @Test
+    void filterNoOpsOnNonStartPaths() {
+        RequestThreadContext.get().setTenant("tenant1");
+        RequestThreadContext.get().setClientId("client1");
+
+        filter.filter(contextFor("v3/workflow/resume/WF-123", "order-123"));
+
+        assertNull(RequestThreadContext.get().getResolvedWorkflowId());
+    }
+
+    @Test
+    void optionalTrueAndNoHeaderPreservesLegacyPath() {
+        RequestThreadContext.get().setTenant("tenant1");
+        RequestThreadContext.get().setClientId("client1");
+
+        filter.filter(contextFor("v3/workflow/start", null));
+
+        assertNull(RequestThreadContext.get().getResolvedWorkflowId());
+    }
+
+    @Test
+    void malformedHeaderThrows400() {
+        RequestThreadContext.get().setTenant("tenant1");
+        RequestThreadContext.get().setClientId("client1");
+
+        assertThrows(ApiException.class,
+                () -> filter.filter(contextFor("v3/workflow/start", "bad key!")));
+    }
+
+    @Test
+    void missingHeaderWithOptionalFalseThrows400() {
+        IdempotencyConfig config = new IdempotencyConfig();
+        config.setHeaders(List.of(HEADER));
+        config.setOptional(false);
+        IdempotencyKeyResolver resolver = new IdempotencyKeyResolver(config);
+        IdempotencyFilter strictFilter = new IdempotencyFilter(resolver);
+
+        RequestThreadContext.get().setTenant("tenant1");
+        RequestThreadContext.get().setClientId("client1");
+
+        assertThrows(ApiException.class,
+                () -> strictFilter.filter(contextFor("v3/workflow/start", null)));
+    }
+
+    @Test
+    void ambiguousHeadersThrows400() {
+        IdempotencyConfig config = new IdempotencyConfig();
+        config.setHeaders(List.of(HEADER, "X_REQUEST_ID"));
+        config.setOptional(true);
+        IdempotencyKeyResolver resolver = new IdempotencyKeyResolver(config);
+        IdempotencyFilter ambiguousFilter = new IdempotencyFilter(resolver);
+
+        RequestThreadContext.get().setTenant("tenant1");
+        RequestThreadContext.get().setClientId("client1");
+
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(uriInfo.getPath()).thenReturn("v3/workflow/start");
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        MultivaluedMap<String, String> headers = new MultivaluedStringMap();
+        headers.add(HEADER, "key-1");
+        headers.add("X_REQUEST_ID", "key-2");
+        when(ctx.getHeaders()).thenReturn(headers);
+
+        assertThrows(ApiException.class, () -> ambiguousFilter.filter(ctx));
+    }
+}

--- a/api/src/test/java/com/flipkart/drift/api/filters/RequestThreadContextTest.java
+++ b/api/src/test/java/com/flipkart/drift/api/filters/RequestThreadContextTest.java
@@ -1,0 +1,58 @@
+package com.flipkart.drift.api.filters;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class RequestThreadContextTest {
+
+    @AfterEach
+    void tearDown() {
+        RequestThreadContext.remove();
+    }
+
+    @Test
+    void clearResetsAllFieldsIncludingIdempotencyFields() {
+        RequestThreadContext ctx = RequestThreadContext.get();
+        ctx.setClientId("client-1");
+        ctx.setTenant("tenant-1");
+        ctx.setUsername("user-1");
+        ctx.setPerfFlag(true);
+        ctx.setResolvedWorkflowId("WF-tenant-client-abc123");
+        ctx.setIdempotencyKey("raw-key");
+        ctx.setResolvedFromExistingWorkflow(true);
+
+        ctx.clear();
+
+        assertNull(ctx.getClientId());
+        assertNull(ctx.getTenant());
+        assertNull(ctx.getUsername());
+        assertNull(ctx.getPerfFlag());
+        assertNull(ctx.getResolvedWorkflowId());
+        assertNull(ctx.getIdempotencyKey());
+        assertFalse(ctx.isResolvedFromExistingWorkflow());
+    }
+
+    @Test
+    void legacyThreadContextIncludesIdempotencyKeyOnlyNotResolvedFields() {
+        RequestThreadContext ctx = RequestThreadContext.get();
+        ctx.clear();
+        ctx.setTenant("tenant-1");
+        ctx.setUsername("user-1");
+        ctx.setClientId("client-1");
+        ctx.setIdempotencyKey("raw-key");
+        ctx.setResolvedWorkflowId("WF-tenant-client-abc123");
+        ctx.setResolvedFromExistingWorkflow(true);
+
+        Map<String, String> legacy = ctx.getLegacyThreadContext();
+
+        assertEquals("raw-key", legacy.get("idempotencyKey"));
+        assertFalse(legacy.containsKey("resolvedWorkflowId"));
+        assertFalse(legacy.containsKey("resolvedFromExistingWorkflow"));
+    }
+}

--- a/api/src/test/java/com/flipkart/drift/api/filters/ResponseFilterTest.java
+++ b/api/src/test/java/com/flipkart/drift/api/filters/ResponseFilterTest.java
@@ -1,0 +1,73 @@
+package com.flipkart.drift.api.filters;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ResponseFilterTest {
+
+    private final ResponseFilter responseFilter = new ResponseFilter();
+
+    @AfterEach
+    void tearDown() {
+        RequestThreadContext.remove();
+    }
+
+    private ContainerResponseContext respond() {
+        ContainerResponseContext ctx = mock(ContainerResponseContext.class);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        when(ctx.getHeaders()).thenReturn(headers);
+        return ctx;
+    }
+
+    private ContainerRequestContext request() {
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        when(ctx.getHeaders()).thenReturn(new javax.ws.rs.core.MultivaluedHashMap<>());
+        return ctx;
+    }
+
+    @Test
+    void workflowIdHeaderPresentWhenResolved() {
+        RequestThreadContext.get().setResolvedWorkflowId("WF-tenant1-client1-abc");
+        RequestThreadContext.get().setResolvedFromExistingWorkflow(false);
+
+        ContainerResponseContext response = respond();
+        responseFilter.filter(request(), response);
+
+        assertTrue(response.getHeaders().containsKey(ResponseFilter.WORKFLOW_ID_HEADER));
+        assertFalse(response.getHeaders().containsKey(ResponseFilter.IDEMPOTENT_REPLAY_HEADER));
+    }
+
+    @Test
+    void idempotentReplayHeaderPresentOnlyWhenResolvedFromExistingWorkflow() {
+        RequestThreadContext.get().setResolvedWorkflowId("WF-tenant1-client1-abc");
+        RequestThreadContext.get().setResolvedFromExistingWorkflow(true);
+
+        ContainerResponseContext response = respond();
+        responseFilter.filter(request(), response);
+
+        assertTrue(response.getHeaders().containsKey(ResponseFilter.WORKFLOW_ID_HEADER));
+        assertTrue(response.getHeaders().containsKey(ResponseFilter.IDEMPOTENT_REPLAY_HEADER));
+        assertTrue(response.getHeaders().getFirst(ResponseFilter.IDEMPOTENT_REPLAY_HEADER).toString().equals("true"));
+    }
+
+    @Test
+    void neitherHeaderPresentForLegacyRequest() {
+        RequestThreadContext.get().clear();
+
+        ContainerResponseContext response = respond();
+        responseFilter.filter(request(), response);
+
+        assertFalse(response.getHeaders().containsKey(ResponseFilter.WORKFLOW_ID_HEADER));
+        assertFalse(response.getHeaders().containsKey(ResponseFilter.IDEMPOTENT_REPLAY_HEADER));
+    }
+}

--- a/api/src/test/java/com/flipkart/drift/api/it/BusinessKeyIdempotencyIT.java
+++ b/api/src/test/java/com/flipkart/drift/api/it/BusinessKeyIdempotencyIT.java
@@ -1,0 +1,236 @@
+package com.flipkart.drift.api.it;
+
+import com.codahale.metrics.MetricRegistry;
+import com.flipkart.drift.api.config.DriftConfiguration;
+import com.flipkart.drift.api.config.IdempotencyConfig;
+import com.flipkart.drift.api.filters.IdempotencyFilter;
+import com.flipkart.drift.api.filters.RequestThreadContext;
+import com.flipkart.drift.api.filters.ResponseFilter;
+import com.flipkart.drift.api.service.RedisPubSubService;
+import com.flipkart.drift.api.service.TemporalService;
+import com.flipkart.drift.api.service.idempotency.IdempotencyMetrics;
+import com.flipkart.drift.api.service.utils.IdempotencyKeyResolver;
+import com.flipkart.drift.api.service.utils.Utility;
+import com.flipkart.drift.sdk.model.enums.WorkflowStatus;
+import com.flipkart.drift.sdk.model.request.WorkflowStartRequest;
+import com.flipkart.drift.sdk.model.response.WorkflowResponse;
+import com.flipkart.drift.workflows.GenericWorkflow;
+import io.temporal.testing.TestWorkflowEnvironment;
+import io.temporal.worker.Worker;
+import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * End-to-end idempotency round trip driven through the real collaborators
+ * (IdempotencyKeyResolver -> IdempotencyFilter -> TemporalService -> ResponseFilter) against
+ * Temporal's in-memory {@link TestWorkflowEnvironment}.
+ * <p>
+ * Deviation from a literal HTTP-layer test: this repo has no jersey-test-framework/grizzly
+ * dependency wired anywhere (verified across all poms), so rather than adding new test
+ * infrastructure this test drives the same production filter/service objects directly with
+ * mocked JAX-RS context interfaces (the framework boundary, not an internal class) --
+ * functionally equivalent coverage of the request -> filter -> TemporalService -> Temporal
+ * round trip without a live HTTP server.
+ */
+class BusinessKeyIdempotencyIT {
+
+    private static final String HEADER = "X-Drift-Idempotency-Key";
+    private static TestWorkflowEnvironment testEnv;
+    private static Worker worker;
+
+    private IdempotencyFilter filter;
+    private TemporalService temporalService;
+    private ResponseFilter responseFilter;
+
+    @BeforeAll
+    static void startTemporalTestEnvironment() {
+        testEnv = TestWorkflowEnvironment.newInstance();
+        worker = testEnv.newWorker("business-key-idempotency-it-queue");
+        worker.registerWorkflowImplementationTypes(FakeGenericWorkflowImpl.class);
+        testEnv.start();
+    }
+
+    @AfterAll
+    static void stopTemporalTestEnvironment() {
+        testEnv.close();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        DriftConfiguration configuration = new DriftConfiguration();
+        configuration.setTemporalFrontEnd("localhost:7233");
+        configuration.setTemporalTaskQueue("business-key-idempotency-it-queue");
+        IdempotencyConfig idempotencyConfig = new IdempotencyConfig();
+        idempotencyConfig.setHeaders(List.of(HEADER));
+        idempotencyConfig.setOptional(true);
+        configuration.setIdempotencyConfig(idempotencyConfig);
+
+        IdempotencyKeyResolver resolver = new IdempotencyKeyResolver(idempotencyConfig);
+        IdempotencyMetrics metrics = new IdempotencyMetrics(new MetricRegistry());
+        filter = new IdempotencyFilter(resolver);
+        responseFilter = new ResponseFilter();
+
+        RedisPubSubService redisPubSubService = mock(RedisPubSubService.class);
+        org.mockito.Mockito.doAnswer(invocation -> {
+            java.util.concurrent.Callable<Void> action = invocation.getArgument(1);
+            action.call();
+            return null;
+        }).when(redisPubSubService).subscribeAndExecute(org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+
+        temporalService = new TemporalService(redisPubSubService, configuration, new Utility(), metrics);
+        Field clientField = TemporalService.class.getDeclaredField("client");
+        clientField.setAccessible(true);
+        clientField.set(temporalService, testEnv.getWorkflowClient());
+
+        RequestThreadContext.get().clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestThreadContext.remove();
+    }
+
+    private void resolveIdempotencyHeader(String tenant, String clientId, String rawKey) {
+        RequestThreadContext.get().setTenant(tenant);
+        RequestThreadContext.get().setClientId(clientId);
+
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(uriInfo.getPath()).thenReturn("v3/workflow/start");
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        MultivaluedMap<String, String> headers = new MultivaluedStringMap();
+        headers.add(HEADER, rawKey);
+        when(ctx.getHeaders()).thenReturn(headers);
+
+        filter.filter(ctx);
+    }
+
+    private WorkflowResponse startViaTemporalService(boolean shouldFail) {
+        WorkflowStartRequest request = new WorkflowStartRequest();
+        Map<String, Object> params = new HashMap<>();
+        params.put("shouldFail", shouldFail);
+        request.setParams(params);
+        return temporalService.startWorkflow(request);
+    }
+
+    private Map<String, List<Object>> responseHeadersFor() {
+        ContainerRequestContext requestCtx = mock(ContainerRequestContext.class);
+        when(requestCtx.getHeaders()).thenReturn(new MultivaluedHashMap<>());
+        ContainerResponseContext responseCtx = mock(ContainerResponseContext.class);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        when(responseCtx.getHeaders()).thenReturn(headers);
+        responseFilter.filter(requestCtx, responseCtx);
+        return headers;
+    }
+
+    @Test
+    void duplicateRequestsResolveToSameWorkflowIdAndOneExecution() {
+        resolveIdempotencyHeader("tenant1", "client1", "order-dup-1");
+        WorkflowResponse first = startViaTemporalService(false);
+        boolean firstReplay = RequestThreadContext.get().isResolvedFromExistingWorkflow();
+
+        // Second POST ~immediately after (simulating "~100ms apart"), same key
+        resolveIdempotencyHeader("tenant1", "client1", "order-dup-1");
+        WorkflowResponse second = startViaTemporalService(false);
+        boolean secondReplay = RequestThreadContext.get().isResolvedFromExistingWorkflow();
+
+        assertEquals(first.getWorkflowId(), second.getWorkflowId());
+        assertFalse(firstReplay);
+        assertTrue(secondReplay);
+    }
+
+    @Test
+    void sameKeyDifferentClientIdsProduceDistinctWorkflowIds() {
+        resolveIdempotencyHeader("tenant1", "client1", "order-shared-key");
+        WorkflowResponse first = startViaTemporalService(false);
+
+        resolveIdempotencyHeader("tenant1", "client2", "order-shared-key");
+        WorkflowResponse second = startViaTemporalService(false);
+
+        assertNotEquals(first.getWorkflowId(), second.getWorkflowId());
+    }
+
+    @Test
+    void sameKeyDifferentTenantsProduceDistinctWorkflowIds() {
+        resolveIdempotencyHeader("tenant1", "client1", "order-shared-key-2");
+        WorkflowResponse first = startViaTemporalService(false);
+
+        resolveIdempotencyHeader("tenant2", "client1", "order-shared-key-2");
+        WorkflowResponse second = startViaTemporalService(false);
+
+        assertNotEquals(first.getWorkflowId(), second.getWorkflowId());
+    }
+
+    @Test
+    void retryAfterFailedRunSucceedsAndReRuns() {
+        resolveIdempotencyHeader("tenant1", "client1", "order-retry-1");
+        WorkflowResponse failedRun = startViaTemporalService(true);
+        assertEquals(WorkflowStatus.FAILED, failedRun.getWorkflowStatus());
+
+        resolveIdempotencyHeader("tenant1", "client1", "order-retry-1");
+        WorkflowResponse retried = startViaTemporalService(false);
+
+        assertEquals(failedRun.getWorkflowId(), retried.getWorkflowId());
+        assertEquals(WorkflowStatus.COMPLETED, retried.getWorkflowStatus());
+    }
+
+    @Test
+    void legacyRequestWithoutHeaderKeepsAutoGeneratedIdAndTerminateIfRunning() {
+        RequestThreadContext.get().setTenant("tenant1");
+        RequestThreadContext.get().setClientId("client1");
+        // no idempotency header resolved -- filter never invoked, legacy path
+
+        WorkflowStartRequest request = new WorkflowStartRequest();
+        WorkflowResponse response = temporalService.startWorkflow(request);
+
+        assertTrue(response.getWorkflowId().startsWith("WF-"));
+        assertNull(RequestThreadContext.get().getResolvedWorkflowId());
+    }
+
+    @Test
+    void responseHeadersEndToEndForFreshDuplicateAndLegacyRequests() {
+        resolveIdempotencyHeader("tenant1", "client1", "order-headers-1");
+        startViaTemporalService(false);
+        Map<String, List<Object>> freshHeaders = responseHeadersFor();
+        assertTrue(freshHeaders.containsKey(ResponseFilter.WORKFLOW_ID_HEADER));
+        assertFalse(freshHeaders.containsKey(ResponseFilter.IDEMPOTENT_REPLAY_HEADER));
+
+        resolveIdempotencyHeader("tenant1", "client1", "order-headers-1");
+        startViaTemporalService(false);
+        Map<String, List<Object>> replayHeaders = responseHeadersFor();
+        assertTrue(replayHeaders.containsKey(ResponseFilter.WORKFLOW_ID_HEADER));
+        assertEquals(freshHeaders.get(ResponseFilter.WORKFLOW_ID_HEADER), replayHeaders.get(ResponseFilter.WORKFLOW_ID_HEADER));
+        assertTrue(replayHeaders.containsKey(ResponseFilter.IDEMPOTENT_REPLAY_HEADER));
+
+        RequestThreadContext.get().clear();
+        RequestThreadContext.get().setTenant("tenant1");
+        RequestThreadContext.get().setClientId("client1");
+        temporalService.startWorkflow(new WorkflowStartRequest());
+        Map<String, List<Object>> legacyHeaders = responseHeadersFor();
+        assertFalse(legacyHeaders.containsKey(ResponseFilter.WORKFLOW_ID_HEADER));
+        assertFalse(legacyHeaders.containsKey(ResponseFilter.IDEMPOTENT_REPLAY_HEADER));
+    }
+}

--- a/api/src/test/java/com/flipkart/drift/api/it/FakeGenericWorkflowImpl.java
+++ b/api/src/test/java/com/flipkart/drift/api/it/FakeGenericWorkflowImpl.java
@@ -1,0 +1,66 @@
+package com.flipkart.drift.api.it;
+
+import com.flipkart.drift.commons.model.temporal.WorkflowState;
+import com.flipkart.drift.sdk.model.enums.WorkflowStatus;
+import com.flipkart.drift.sdk.model.request.WorkflowResumeRequest;
+import com.flipkart.drift.sdk.model.request.WorkflowStartRequest;
+import com.flipkart.drift.sdk.model.request.WorkflowTerminateRequest;
+import com.flipkart.drift.sdk.model.request.WorkflowUtilityRequest;
+import com.flipkart.drift.sdk.model.response.WorkflowUtilityResponse;
+import com.flipkart.drift.workflows.GenericWorkflow;
+import io.temporal.failure.ApplicationFailure;
+import io.temporal.workflow.Workflow;
+
+/**
+ * Minimal test-only {@link GenericWorkflow} implementation used exclusively by
+ * {@link BusinessKeyIdempotencyIT} against Temporal's in-memory {@code TestWorkflowEnvironment}.
+ * The real implementation lives in the {@code worker} module, which {@code api} must never
+ * depend on (ARCHITECTURE_RULES.md, {@code apiMustNotDependOnWorker}) -- this fake stands in
+ * for it so the integration test can exercise a genuine Temporal round-trip without violating
+ * that boundary. Deliberately trivial: honors an optional {@code shouldFail} param to simulate
+ * a FAILED run for the retry-after-failure scenario.
+ */
+public class FakeGenericWorkflowImpl implements GenericWorkflow {
+
+    private WorkflowStatus status = WorkflowStatus.RUNNING;
+    private String incidentId;
+
+    private String workflowId;
+
+    @Override
+    public void startWorkflow(WorkflowStartRequest workflowStartRequest) {
+        workflowId = Workflow.getInfo().getWorkflowId();
+        incidentId = workflowStartRequest.getIncidentId();
+        boolean shouldFail = workflowStartRequest.getParams() != null
+                && Boolean.TRUE.equals(workflowStartRequest.getParams().get("shouldFail"));
+        if (shouldFail) {
+            status = WorkflowStatus.FAILED;
+            throw ApplicationFailure.newNonRetryableFailure("simulated failure", "TestFailure");
+        }
+        status = WorkflowStatus.COMPLETED;
+    }
+
+    @Override
+    public void resumeWorkflow(WorkflowResumeRequest workflowResumeRequest) {
+        // not exercised by this integration test
+    }
+
+    @Override
+    public void terminateWorkflow(WorkflowTerminateRequest workflowTerminateRequest) {
+        status = WorkflowStatus.TERMINATED;
+    }
+
+    @Override
+    public WorkflowState getWorkflowState() {
+        WorkflowState state = new WorkflowState();
+        state.setWorkflowId(workflowId);
+        state.setIncidentId(incidentId);
+        state.setStatus(status);
+        return state;
+    }
+
+    @Override
+    public WorkflowUtilityResponse executeDisconnectedNode(WorkflowUtilityRequest workflowUtilityRequest) {
+        return null;
+    }
+}

--- a/api/src/test/java/com/flipkart/drift/api/service/TemporalServiceTest.java
+++ b/api/src/test/java/com/flipkart/drift/api/service/TemporalServiceTest.java
@@ -1,0 +1,162 @@
+package com.flipkart.drift.api.service;
+
+import com.codahale.metrics.MetricRegistry;
+import com.flipkart.drift.api.config.DriftConfiguration;
+import com.flipkart.drift.api.config.IdempotencyConfig;
+import com.flipkart.drift.api.filters.RequestThreadContext;
+import com.flipkart.drift.api.service.idempotency.IdempotencyMetrics;
+import com.flipkart.drift.api.service.utils.Utility;
+import com.flipkart.drift.commons.model.temporal.WorkflowState;
+import com.flipkart.drift.sdk.model.request.WorkflowStartRequest;
+import com.flipkart.drift.sdk.model.response.WorkflowResponse;
+import com.flipkart.drift.workflows.GenericWorkflow;
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.enums.v1.WorkflowIdReusePolicy;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowExecutionAlreadyStarted;
+import io.temporal.client.WorkflowOptions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Mocks only the Temporal client (system boundary, per TEST.md) via reflection field
+ * injection -- TemporalService's constructor builds its WorkflowClient internally rather
+ * than accepting one, so a mock is swapped in post-construction rather than via DI. This
+ * avoids a larger constructor-injection refactor outside subtask-6's declared scope while
+ * still keeping the mock at the correct boundary (RequestThreadContext is NOT mocked).
+ */
+class TemporalServiceTest {
+
+    private TemporalService temporalService;
+    private WorkflowClient mockClient;
+    private RedisPubSubService redisPubSubService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        DriftConfiguration configuration = new DriftConfiguration();
+        configuration.setTemporalFrontEnd("localhost:7233");
+        configuration.setTemporalTaskQueue("test-queue");
+        IdempotencyConfig idempotencyConfig = new IdempotencyConfig();
+        configuration.setIdempotencyConfig(idempotencyConfig);
+
+        redisPubSubService = mock(RedisPubSubService.class);
+        Utility utility = new Utility();
+        IdempotencyMetrics idempotencyMetrics = new IdempotencyMetrics(new MetricRegistry());
+
+        temporalService = new TemporalService(redisPubSubService, configuration, utility, idempotencyMetrics);
+
+        mockClient = mock(WorkflowClient.class);
+        Field clientField = TemporalService.class.getDeclaredField("client");
+        clientField.setAccessible(true);
+        clientField.set(temporalService, mockClient);
+
+        RequestThreadContext.get().clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestThreadContext.remove();
+    }
+
+    private WorkflowState stateFor(String workflowId) {
+        WorkflowState state = new WorkflowState();
+        state.setWorkflowId(workflowId);
+        state.setDisposition("SUCCESS");
+        return state;
+    }
+
+    @Test
+    void nonIdempotentRequestUsesTerminateIfRunningReusePolicy() {
+        GenericWorkflow workflowStub = mock(GenericWorkflow.class);
+        when(mockClient.newWorkflowStub(org.mockito.ArgumentMatchers.eq(GenericWorkflow.class),
+                any(WorkflowOptions.class))).thenAnswer(invocation -> {
+            WorkflowOptions options = invocation.getArgument(1);
+            assertEquals(WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
+                    options.getWorkflowIdReusePolicy());
+            return workflowStub;
+        });
+        when(workflowStub.getWorkflowState()).thenReturn(stateFor("WF-legacy-1"));
+
+        WorkflowStartRequest request = new WorkflowStartRequest();
+        request.setWorkflowId("WF-legacy-1");
+
+        WorkflowResponse response = temporalService.executeWorkflow(request);
+
+        assertEquals("WF-legacy-1", response.getWorkflowId());
+        assertFalse(RequestThreadContext.get().isResolvedFromExistingWorkflow());
+    }
+
+    @Test
+    void idempotentRequestUsesAllowDuplicateFailedOnlyReusePolicy() {
+        RequestThreadContext.get().setResolvedWorkflowId("WF-tenant1-client1-abc");
+        RequestThreadContext.get().setTenant("tenant1");
+        RequestThreadContext.get().setClientId("client1");
+
+        GenericWorkflow workflowStub = mock(GenericWorkflow.class);
+        when(mockClient.newWorkflowStub(org.mockito.ArgumentMatchers.eq(GenericWorkflow.class),
+                any(WorkflowOptions.class))).thenAnswer(invocation -> {
+            WorkflowOptions options = invocation.getArgument(1);
+            assertEquals(WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
+                    options.getWorkflowIdReusePolicy());
+            return workflowStub;
+        });
+        when(workflowStub.getWorkflowState()).thenReturn(stateFor("WF-tenant1-client1-abc"));
+
+        WorkflowStartRequest request = new WorkflowStartRequest();
+        request.setWorkflowId("WF-tenant1-client1-abc");
+
+        WorkflowResponse response = temporalService.executeWorkflow(request);
+
+        assertEquals("WF-tenant1-client1-abc", response.getWorkflowId());
+    }
+
+    @Test
+    void alreadyStartedTranslatesToExistingStateFetch() {
+        RequestThreadContext.get().setResolvedWorkflowId("WF-tenant1-client1-dup");
+        RequestThreadContext.get().setTenant("tenant1");
+        RequestThreadContext.get().setClientId("client1");
+
+        WorkflowExecution execution = WorkflowExecution.newBuilder().setWorkflowId("WF-tenant1-client1-dup").build();
+        WorkflowExecutionAlreadyStarted alreadyStarted =
+                new WorkflowExecutionAlreadyStarted(execution, "GenericWorkflow", null);
+
+        GenericWorkflow startingStub = mock(GenericWorkflow.class);
+        GenericWorkflow existingStub = mock(GenericWorkflow.class);
+
+        when(mockClient.newWorkflowStub(org.mockito.ArgumentMatchers.eq(GenericWorkflow.class),
+                any(WorkflowOptions.class))).thenReturn(startingStub);
+        when(mockClient.newWorkflowStub(GenericWorkflow.class, "WF-tenant1-client1-dup")).thenReturn(existingStub);
+        when(existingStub.getWorkflowState()).thenReturn(stateFor("WF-tenant1-client1-dup"));
+
+        doThrowFromSubscribeAndExecute(alreadyStarted);
+
+        WorkflowStartRequest request = new WorkflowStartRequest();
+        request.setWorkflowId("WF-tenant1-client1-dup");
+
+        WorkflowResponse response = temporalService.executeWorkflow(request);
+
+        assertEquals("WF-tenant1-client1-dup", response.getWorkflowId());
+        assertTrue(RequestThreadContext.get().isResolvedFromExistingWorkflow());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void doThrowFromSubscribeAndExecute(Exception toThrow) {
+        try {
+            org.mockito.Mockito.doAnswer(invocation -> {
+                throw toThrow;
+            }).when(redisPubSubService).subscribeAndExecute(any(), any(), any());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/api/src/test/java/com/flipkart/drift/api/service/idempotency/IdempotencyMetricsTest.java
+++ b/api/src/test/java/com/flipkart/drift/api/service/idempotency/IdempotencyMetricsTest.java
@@ -1,0 +1,64 @@
+package com.flipkart.drift.api.service.idempotency;
+
+import com.codahale.metrics.MetricRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IdempotencyMetricsTest {
+
+    @Test
+    void missMarksPerTenantClientMeter() {
+        MetricRegistry registry = new MetricRegistry();
+        IdempotencyMetrics metrics = new IdempotencyMetrics(registry);
+
+        metrics.miss("Tenant-1", "Client-1");
+
+        assertEquals(1, registry.meter(IdempotencyMetrics.MISS + ".tenant-1.client-1").getCount());
+    }
+
+    @Test
+    void alreadyStartedMarksPerTenantClientMeter() {
+        MetricRegistry registry = new MetricRegistry();
+        IdempotencyMetrics metrics = new IdempotencyMetrics(registry);
+
+        metrics.alreadyStarted("Tenant-1", "Client-1");
+
+        assertEquals(1, registry.meter(IdempotencyMetrics.ALREADY_STARTED + ".tenant-1.client-1").getCount());
+    }
+
+    @Test
+    void historyPurgedMarksPerTenantClientMeter() {
+        MetricRegistry registry = new MetricRegistry();
+        IdempotencyMetrics metrics = new IdempotencyMetrics(registry);
+
+        metrics.historyPurged("Tenant-1", "Client-1");
+
+        assertEquals(1, registry.meter(IdempotencyMetrics.HISTORY_PURGED + ".tenant-1.client-1").getCount());
+    }
+
+    @Test
+    void differentTenantsProduceSeparateMeters() {
+        MetricRegistry registry = new MetricRegistry();
+        IdempotencyMetrics metrics = new IdempotencyMetrics(registry);
+
+        metrics.miss("tenantA", "web");
+        metrics.miss("tenantA", "web");
+        metrics.miss("tenantB", "web");
+
+        assertEquals(2, registry.meter(IdempotencyMetrics.MISS + ".tenanta.web").getCount());
+        assertEquals(1, registry.meter(IdempotencyMetrics.MISS + ".tenantb.web").getCount());
+    }
+
+    @Test
+    void differentClientsProduceSeparateMeters() {
+        MetricRegistry registry = new MetricRegistry();
+        IdempotencyMetrics metrics = new IdempotencyMetrics(registry);
+
+        metrics.miss("tenant1", "web");
+        metrics.miss("tenant1", "mobile");
+
+        assertEquals(1, registry.meter(IdempotencyMetrics.MISS + ".tenant1.web").getCount());
+        assertEquals(1, registry.meter(IdempotencyMetrics.MISS + ".tenant1.mobile").getCount());
+    }
+}

--- a/api/src/test/java/com/flipkart/drift/api/service/utils/IdempotencyKeyResolverTest.java
+++ b/api/src/test/java/com/flipkart/drift/api/service/utils/IdempotencyKeyResolverTest.java
@@ -1,0 +1,126 @@
+package com.flipkart.drift.api.service.utils;
+
+import com.flipkart.drift.api.config.IdempotencyConfig;
+import com.flipkart.drift.api.exception.ApiException;
+import com.flipkart.drift.api.filters.IdempotencyKey;
+import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IdempotencyKeyResolverTest {
+
+    private static final String HEADER = "X-Drift-Idempotency-Key";
+
+    private IdempotencyConfig config(boolean optional, String... headers) {
+        IdempotencyConfig config = new IdempotencyConfig();
+        config.setHeaders(List.of(headers));
+        config.setOptional(optional);
+        return config;
+    }
+
+    private MultivaluedMap<String, String> headersWith(String name, String value) {
+        MultivaluedMap<String, String> headers = new MultivaluedStringMap();
+        if (value != null) {
+            headers.add(name, value);
+        }
+        return headers;
+    }
+
+    @Test
+    void headerAbsentAndOptionalTrueReturnsEmpty() {
+        IdempotencyKeyResolver resolver = new IdempotencyKeyResolver(config(true, HEADER));
+        Optional<String> result = resolver.extractRawKey(new MultivaluedStringMap());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void headerAbsentAndOptionalFalseThrows400Missing() {
+        IdempotencyKeyResolver resolver = new IdempotencyKeyResolver(config(false, HEADER));
+        ApiException ex = assertThrows(ApiException.class,
+                () -> resolver.extractRawKey(new MultivaluedStringMap()));
+        assertEquals(IdempotencyKeyResolver.ERROR_MISSING, ex.getErrorCode());
+    }
+
+    @Test
+    void multipleHeadersWithConflictingValuesThrowsAmbiguous() {
+        IdempotencyKeyResolver resolver = new IdempotencyKeyResolver(config(true, HEADER, "X_REQUEST_ID"));
+        MultivaluedMap<String, String> headers = new MultivaluedStringMap();
+        headers.add(HEADER, "key-1");
+        headers.add("X_REQUEST_ID", "key-2");
+
+        ApiException ex = assertThrows(ApiException.class, () -> resolver.extractRawKey(headers));
+        assertEquals(IdempotencyKeyResolver.ERROR_AMBIGUOUS, ex.getErrorCode());
+    }
+
+    @Test
+    void malformedKeyThrows400Malformed() {
+        IdempotencyKeyResolver resolver = new IdempotencyKeyResolver(config(true, HEADER));
+        MultivaluedMap<String, String> headers = headersWith(HEADER, "bad key with spaces!");
+
+        ApiException ex = assertThrows(ApiException.class, () -> resolver.extractRawKey(headers));
+        assertEquals(IdempotencyKeyResolver.ERROR_MALFORMED, ex.getErrorCode());
+    }
+
+    @Test
+    void happyPathResolvesKeyAndWorkflowId() {
+        IdempotencyKeyResolver resolver = new IdempotencyKeyResolver(config(true, HEADER));
+        MultivaluedMap<String, String> headers = headersWith(HEADER, "order-123");
+
+        Optional<String> rawKey = resolver.extractRawKey(headers);
+        assertTrue(rawKey.isPresent());
+        assertEquals("order-123", rawKey.get());
+
+        IdempotencyKey key = resolver.resolve("tenant1", "client1", rawKey.get());
+        assertTrue(key.getWorkflowId().startsWith("WF-tenant1-client1-"));
+    }
+
+    @Test
+    void toWorkflowIdIncludesTenantAndClientIdAndSha256() {
+        IdempotencyKeyResolver resolver = new IdempotencyKeyResolver(config(true, HEADER));
+        String workflowId = resolver.toWorkflowId("Tenant1", "Client1", "raw-key");
+        assertTrue(workflowId.startsWith("WF-tenant1-client1-"));
+        assertEquals(64, workflowId.substring("WF-tenant1-client1-".length()).length());
+    }
+
+    @Test
+    void differentClientIdsProduceDifferentWorkflowIds() {
+        IdempotencyKeyResolver resolver = new IdempotencyKeyResolver(config(true, HEADER));
+        String id1 = resolver.toWorkflowId("tenant1", "client1", "raw-key");
+        String id2 = resolver.toWorkflowId("tenant1", "client2", "raw-key");
+        assertNotEquals(id1, id2);
+    }
+
+    @Test
+    void differentTenantsProduceDifferentWorkflowIds() {
+        IdempotencyKeyResolver resolver = new IdempotencyKeyResolver(config(true, HEADER));
+        String id1 = resolver.toWorkflowId("tenant1", "client1", "raw-key");
+        String id2 = resolver.toWorkflowId("tenant2", "client1", "raw-key");
+        assertNotEquals(id1, id2);
+    }
+
+    @Test
+    void ambiguousPrefixSplitsProduceDistinctWorkflowIds() {
+        // tenant="tenantA", clientId="B-C" and tenant="tenantA-B", clientId="C" both
+        // lower-case to the same "tenanta-b-c" prefix — the hash must keep them distinct.
+        IdempotencyKeyResolver resolver = new IdempotencyKeyResolver(config(true, HEADER));
+        String id1 = resolver.toWorkflowId("tenantA", "B-C", "same-key");
+        String id2 = resolver.toWorkflowId("tenantA-B", "C", "same-key");
+        assertNotEquals(id1, id2);
+    }
+
+    @Test
+    void differentRawKeysNeverCollide() {
+        IdempotencyKeyResolver resolver = new IdempotencyKeyResolver(config(true, HEADER));
+        String id1 = resolver.toWorkflowId("tenant1", "client1", "raw-key-a");
+        String id2 = resolver.toWorkflowId("tenant1", "client1", "raw-key-b");
+        assertNotEquals(id1, id2);
+    }
+}

--- a/commons/src/main/java/com/flipkart/drift/commons/model/temporal/WorkflowState.java
+++ b/commons/src/main/java/com/flipkart/drift/commons/model/temporal/WorkflowState.java
@@ -2,6 +2,7 @@ package com.flipkart.drift.commons.model.temporal;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.flipkart.drift.sdk.model.client.IssueDetail;
+import com.flipkart.drift.sdk.model.enums.WorkflowExecutionMode;
 import com.flipkart.drift.sdk.model.response.View;
 import com.flipkart.drift.sdk.model.enums.WorkflowStatus;
 import lombok.AllArgsConstructor;
@@ -25,4 +26,6 @@ public class WorkflowState implements Serializable {
     private View view;
     private String currentNodeRef;
     private IssueDetail issueDetail;
+    /** Workflow-level execution mode set when the workflow was started; null for legacy workflows (treated as SYNC). */
+    private WorkflowExecutionMode workflowExecutionMode;
 }

--- a/commons/src/main/java/com/flipkart/drift/commons/model/temporal/WorkflowState.java
+++ b/commons/src/main/java/com/flipkart/drift/commons/model/temporal/WorkflowState.java
@@ -25,4 +25,7 @@ public class WorkflowState implements Serializable {
     private View view;
     private String currentNodeRef;
     private IssueDetail issueDetail;
+    // Resolved workflow DSL identity. Used to execute disconnected nodes when issueDetail is absent.
+    private String workflowDslId;
+    private String workflowVersion;
 }

--- a/docs/_pages/08-API-CONTRACTS.md
+++ b/docs/_pages/08-API-CONTRACTS.md
@@ -174,6 +174,41 @@ public enum WorkflowStatus {
 }
 ```
 
+#### 2.1.1 Business-Key Idempotency (`POST /v3/workflow/start` only)
+
+Applies **only** to `POST /v3/workflow/start`; every other endpoint in this document is
+unaffected. Introduced to let callers safely retry a start request without producing a
+duplicate workflow execution or terminating an in-flight one.
+
+**Request headers**
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `X-Drift-Idempotency-Key` | No (see back-compat note below) | Caller-supplied business key, `1-256` chars, charset `[A-Za-z0-9_\-:.]`. Drift derives the Temporal `workflowId` as `WF-{tenant}-{clientId}-{sha256(tenant NUL clientId NUL rawKey)}`; all three components are bound into the hash so different tenant/clientId splits with the same concatenated prefix never collide; repeating the same key + tenant + clientId always resolves to the same workflow, never starting a second execution. |
+| `X-Request-Id` | No | Accepted as an alias for `X-Drift-Idempotency-Key`, but only if the primary header is absent. Supplying both with **different** values is an error (see below). |
+
+Validation errors return `400 Bad Request` with one of the following `errorCode` values in
+the standard error body:
+
+| `errorCode` | Cause |
+|-------------|-------|
+| `IDEMPOTENCY_KEY_MISSING` | No idempotency header supplied and the server is configured with `optional: false` (not the default). |
+| `IDEMPOTENCY_KEY_AMBIGUOUS` | More than one configured header present with conflicting values. |
+| `IDEMPOTENCY_KEY_MALFORMED` | Header value does not match `[A-Za-z0-9_\-:.]{1,256}`. |
+
+**Response headers**
+
+| Header | When present | Meaning |
+|--------|---------------|---------|
+| `X-Drift-Workflow-Id` | Whenever the request resolved to a business-key-derived `workflowId` (i.e., the idempotency header was supplied and valid) | The Temporal `workflowId` backing this request — the same value on every retry under the same key/tenant/clientId. |
+| `X-Drift-Idempotent-Replay` | Only when the value is literally `true`, and only when the resolved `workflowId` already had a running/completed Temporal execution (i.e., this request was a duplicate of an earlier one) | Signals the caller got back an existing execution's state rather than triggering a new one. **Not** a cache-hit indicator — this deployment has no cache; it means "resolved via a pre-existing Temporal execution." Omitted entirely (not `false`) on a genuine first/fresh start, and omitted entirely for legacy requests without the idempotency header. |
+
+**Back-compat note (default behavior, no header supplied):** `optional: true` is the
+default server configuration, so existing callers that omit `X-Drift-Idempotency-Key`
+entirely are completely unaffected — Drift falls through to the legacy path (`workflowId`
+either taken from the request body if explicitly set, or auto-generated), and neither of
+the response headers above is added.
+
 ### 2.2 Resume Workflow
 
 **Endpoint**: `PUT /v3/workflow/resume/{workflowId}`

--- a/java-sdk/src/main/java/com/flipkart/drift/sdk/model/enums/WorkflowExecutionMode.java
+++ b/java-sdk/src/main/java/com/flipkart/drift/sdk/model/enums/WorkflowExecutionMode.java
@@ -1,0 +1,12 @@
+package com.flipkart.drift.sdk.model.enums;
+
+/**
+ * Controls how the API call behaves when starting or resuming a workflow.
+ * SYNC  - the API thread blocks until the workflow reaches a terminal state (requires Redis).
+ * ASYNC - the API returns immediately with RUNNING status; the workflow completes in the background.
+ * Defaults to SYNC for backward compatibility.
+ */
+public enum WorkflowExecutionMode {
+    ASYNC,
+    SYNC
+}

--- a/java-sdk/src/main/java/com/flipkart/drift/sdk/model/request/WorkflowRequest.java
+++ b/java-sdk/src/main/java/com/flipkart/drift/sdk/model/request/WorkflowRequest.java
@@ -13,6 +13,15 @@ import java.util.Map;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class WorkflowRequest {
     private String incidentId;
+    /**
+     * Legacy/manual Temporal workflow identifier. Prefer letting Drift derive the
+     * workflow id automatically from the {@code X-Drift-Idempotency-Key} request header
+     * on {@code POST /v3/workflow/start} instead of setting this field directly — the
+     * header-derived id gives at-most-one-execution-per-business-key semantics via
+     * Temporal's atomic start, whereas a repeated explicit {@code workflowId} here
+     * terminates and replaces any running execution. This field remains fully
+     * functional for existing callers (no behavior change).
+     */
     private String workflowId;
     private String parentWorkflowId;
     private Map<String, String> threadContext;

--- a/java-sdk/src/main/java/com/flipkart/drift/sdk/model/request/WorkflowStartRequest.java
+++ b/java-sdk/src/main/java/com/flipkart/drift/sdk/model/request/WorkflowStartRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.flipkart.drift.sdk.model.client.Customer;
 import com.flipkart.drift.sdk.model.client.IssueDetail;
 import com.flipkart.drift.sdk.model.client.OrderDetail;
+import com.flipkart.drift.sdk.model.enums.WorkflowExecutionMode;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -28,4 +29,10 @@ public class WorkflowStartRequest extends WorkflowRequest {
     @Deprecated
     private Set<OrderDetail> orderDetails;
     private Map<String, Object> config;
+    /**
+     * Controls whether the API call blocks waiting for a terminal state (SYNC) or returns immediately (ASYNC).
+     * Defaults to SYNC for backward compatibility.
+     * SYNC requires Redis to be enabled; use ASYNC in Redis-free environments.
+     */
+    private WorkflowExecutionMode workflowExecutionMode = WorkflowExecutionMode.SYNC;
 }

--- a/java-sdk/src/main/java/com/flipkart/drift/sdk/model/request/WorkflowStartRequest.java
+++ b/java-sdk/src/main/java/com/flipkart/drift/sdk/model/request/WorkflowStartRequest.java
@@ -9,7 +9,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.Set;
 
@@ -20,7 +19,9 @@ import java.util.Set;
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class WorkflowStartRequest extends WorkflowRequest {
-    @NotNull(message = "issueDetail cannot be null")
+    // Optional/deprecated. Prefer params.workflowId + params.version for workflow resolution.
+    // Retained for backward compatibility: when params do not carry workflowId/version,
+    // issueDetail.issueId is used to look up the workflow mapping.
     @Deprecated
     private IssueDetail issueDetail;
     @Deprecated

--- a/package/helm-chart/api/values.yaml
+++ b/package/helm-chart/api/values.yaml
@@ -38,6 +38,13 @@ env:
   HADOOP_USERNAME: "your-hadoop-username"
   HADOOP_LOGIN_USER: "your-hadoop-login-user"
   ZOOKEEPER_QUORUM_HOT: "your-zookeeper-quorum"
+  # Set to false to disable Redis and use DNS fanout for cache invalidation instead
+  REDIS_ENABLED: ""
+  # DNS name of the worker headless service for cache invalidation fanout (used when REDIS_ENABLED=false).
+  # Format: <worker-release-name>-headless.<namespace>.svc.cluster.local
+  WORKER_HEADLESS_HOST: ""
+  # Admin port of the worker pods (must match the worker's adminConnectors port)
+  WORKER_ADMIN_PORT: ""
 
 jvm:
   heapSize:

--- a/package/helm-chart/worker/templates/headless-service.yaml
+++ b/package/helm-chart/worker/templates/headless-service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.headlessService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-headless
+  namespace: {{ .Values.namespace }}
+  labels:
+{{- range $key, $val := .Values.labels }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
+spec:
+  clusterIP: None  # headless: DNS resolves to individual pod IPs
+  selector:
+{{- range $key, $val := .Values.selectorLabels }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
+  ports:
+    - name: admin
+      port: {{ .Values.headlessService.adminPort }}
+      targetPort: {{ .Values.headlessService.adminPort }}
+      protocol: TCP
+{{- end }}

--- a/package/helm-chart/worker/values.yaml
+++ b/package/helm-chart/worker/values.yaml
@@ -56,6 +56,13 @@ jvm:
     xms: "1g"
     xmx: "1g"
 
+# Headless K8s service so the API can resolve all worker pod IPs for DNS-fanout
+# cache invalidation when Redis is unavailable.
+# DNS name from API pods: <release-name>-headless.<namespace>.svc.cluster.local
+headlessService:
+  enabled: true
+  adminPort: 5601
+
 # Config files - each config is in its own section for easy management
 # These are clean, human-readable configuration files
 configFiles:

--- a/worker/src/main/java/com/flipkart/drift/worker/activities/BaseNodeActivityImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/activities/BaseNodeActivityImpl.java
@@ -15,6 +15,7 @@ import com.flipkart.drift.worker.model.activity.ActivityRequest;
 import com.flipkart.drift.worker.model.activity.ActivityResponse;
 import com.flipkart.drift.worker.service.WorkflowContextHBService;
 import com.flipkart.drift.commons.utils.ObjectMapperUtil;
+import com.flipkart.drift.sdk.model.enums.WorkflowStatus;
 import io.temporal.activity.Activity;
 import lombok.extern.slf4j.Slf4j;
 
@@ -81,6 +82,17 @@ public abstract class BaseNodeActivityImpl<T extends NodeDefinition> implements 
         activityRequest.setNodeDefinition(activityThinRequest.getNodeDefinition());
         // Step 2: Execute the actual logic
         ActivityResponse response = executeNode(activityRequest);
+
+        // Step 2b: If node is marked as terminal (end=true) and the node's own status is still
+        // transitional (RUNNING or WAITING), override to COMPLETED so all node types correctly
+        // terminate the workflow. FAILED, COMPLETED, and ASYNC_COMPLETE are intentional and preserved.
+        if (Boolean.TRUE.equals(activityRequest.getIsTerminal())
+                && response.getWorkflowStatus() != WorkflowStatus.FAILED
+                && response.getWorkflowStatus() != WorkflowStatus.COMPLETED
+                && response.getWorkflowStatus() != WorkflowStatus.ASYNC_COMPLETE) {
+            response.setWorkflowStatus(WorkflowStatus.COMPLETED);
+        }
+
         // Step 3: Persist updated context
         workflowContextHBService.updateEntity(WorkflowContext.builder()
                 .workflowId(workflowId)

--- a/worker/src/main/java/com/flipkart/drift/worker/activities/FetchWorkflowActivityImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/activities/FetchWorkflowActivityImpl.java
@@ -61,8 +61,9 @@ public class FetchWorkflowActivityImpl implements FetchWorkflowActivity {
 
     @Override
     public Workflow fetchWorkflowBasedOnRequest(WorkflowStartRequest request) {
-        String issueId = request.getIssueDetail().getIssueId();
         String tenant = request.getThreadContext().getOrDefault("tenant", "fk");
+
+        // Preferred path: explicit workflowId + version in params. No issueDetail required.
         if (request.getParams() != null) {
             Map<String, Object> params = request.getParams();
             Object workflowId = params.get(WORKFLOW_ID);
@@ -70,6 +71,15 @@ public class FetchWorkflowActivityImpl implements FetchWorkflowActivity {
             if (workflowId != null && version != null) {
                 return fetchWorkflow(workflowId.toString(), version.toString(), tenant);
             }
+        }
+
+        // Backward-compatible fallback: resolve workflow via issueId mapping.
+        String issueId = resolveIssueId(request);
+        if (issueId == null || issueId.trim().isEmpty()) {
+            throw Activity.wrap(new RuntimeException(
+                "Unable to resolve workflow: provide either params." + WORKFLOW_ID +
+                " and params." + VERSION + ", or a valid issueDetail.issueId."
+            ));
         }
 
         IssueWorkflowMapping issueWorkflowMapping = issueWorkflowMappingService.getIssueWorkflowMappingForIssue(issueId);
@@ -95,5 +105,9 @@ public class FetchWorkflowActivityImpl implements FetchWorkflowActivity {
     public WorkflowNode fetchWorkflowNode(String issueId, String nodeName, String tenant) {
         Workflow workflow = fetchWorkflowBasedOnIssueId(issueId, tenant);
         return workflow.getStates().get(nodeName);
+    }
+
+    private static String resolveIssueId(WorkflowStartRequest request) {
+        return request.getIssueDetail() != null ? request.getIssueDetail().getIssueId() : null;
     }
 }

--- a/worker/src/main/java/com/flipkart/drift/worker/activities/InstructionNodeActivityImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/activities/InstructionNodeActivityImpl.java
@@ -64,7 +64,8 @@ public class InstructionNodeActivityImpl extends BaseNodeActivityImpl<Instructio
             if (workflowAttributeDetails != null) {
                 workflowStatus = WorkflowStatus.valueOf(workflowAttributeDetails.getAttribute());
             } else {
-                workflowStatus = activityRequest.getIsTerminal() ? WorkflowStatus.COMPLETED : WorkflowStatus.WAITING;
+                // Always return WAITING here; BaseNodeActivityImpl overrides to COMPLETED when isTerminal=true
+                workflowStatus = WorkflowStatus.WAITING;
             }
 
             return ActivityResponse.builder()

--- a/worker/src/main/java/com/flipkart/drift/worker/activities/ReturnControlActivityImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/activities/ReturnControlActivityImpl.java
@@ -1,6 +1,5 @@
 package com.flipkart.drift.worker.activities;
 
-import com.flipkart.drift.worker.config.RedisConfiguration;
 import com.google.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import redis.clients.jedis.Jedis;
@@ -10,17 +9,12 @@ import static com.flipkart.drift.commons.utils.Constants.Workflow.ASYNC_AWAIT_CH
 
 @Slf4j
 public class ReturnControlActivityImpl implements ReturnControlActivity {
-    private final RedisConfiguration redisConfiguration;
-    private final JedisPoolAbstract jedisSentinelPool;
+
+    @Inject(optional = true)
+    private JedisPoolAbstract jedisSentinelPool;
 
     @Inject
-    public ReturnControlActivityImpl(RedisConfiguration redisConfiguration, JedisPoolAbstract jedisSentinelPool) {
-        this.redisConfiguration = redisConfiguration;
-        this.jedisSentinelPool = jedisSentinelPool;
-    }
-
-    public String getRedisKey(String key) {
-        return redisConfiguration.getPrefix() + ":" + key;
+    public ReturnControlActivityImpl() {
     }
 
     public Long exec(String workflowId) {

--- a/worker/src/main/java/com/flipkart/drift/worker/bootstrap/DslCacheManager.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/bootstrap/DslCacheManager.java
@@ -1,0 +1,59 @@
+package com.flipkart.drift.worker.bootstrap;
+
+import com.flipkart.drift.persistence.cache.EntityVersionedCache;
+import com.flipkart.drift.persistence.cache.NodeDefinitionCache;
+import com.flipkart.drift.persistence.cache.WorkflowCache;
+import com.google.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Shared DSL cache invalidation logic used by both {@link RedisCacheInvalidator}
+ * (Redis pub-sub path) and {@link com.flipkart.drift.worker.task.CacheInvalidationTask}
+ * (DNS-fanout HTTP path).
+ */
+@Slf4j
+public class DslCacheManager {
+
+    public static final String NODE_EVENT_ID = "NODE";
+    public static final String WORKFLOW_EVENT_ID = "WORKFLOW";
+    public static final String ALL = "ALL";
+
+    private final NodeDefinitionCache nodeDefinitionCache;
+    private final WorkflowCache workflowCache;
+
+    @Inject
+    public DslCacheManager(NodeDefinitionCache nodeDefinitionCache, WorkflowCache workflowCache) {
+        this.nodeDefinitionCache = nodeDefinitionCache;
+        this.workflowCache = workflowCache;
+    }
+
+    /**
+     * Invalidates a single cache entry or the entire cache for the given type.
+     *
+     * @param type  "NODE" or "WORKFLOW"
+     * @param key   HBase row key to invalidate, or "ALL" to invalidate the entire cache
+     * @return true if the cache was found and invalidated, false if type is unknown
+     */
+    public boolean invalidate(String type, String key) {
+        EntityVersionedCache<?> cache = getCache(type);
+        if (cache == null) {
+            log.warn("Unknown cache type: {}, ignoring invalidation for key {}", type, key);
+            return false;
+        }
+        log.info("Invalidating cache: type={}, key={}", type, key);
+        if (ALL.equalsIgnoreCase(key)) {
+            cache.invalidateAll();
+        } else {
+            cache.invalidate(key);
+        }
+        return true;
+    }
+
+    private EntityVersionedCache<?> getCache(String type) {
+        switch (type) {
+            case NODE_EVENT_ID: return nodeDefinitionCache;
+            case WORKFLOW_EVENT_ID: return workflowCache;
+            default: return null;
+        }
+    }
+}

--- a/worker/src/main/java/com/flipkart/drift/worker/bootstrap/RedisCacheInvalidator.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/bootstrap/RedisCacheInvalidator.java
@@ -1,8 +1,6 @@
 package com.flipkart.drift.worker.bootstrap;
 
-import com.flipkart.drift.persistence.cache.EntityVersionedCache;
-import com.flipkart.drift.persistence.cache.NodeDefinitionCache;
-import com.flipkart.drift.persistence.cache.WorkflowCache;
+import com.flipkart.drift.worker.config.DriftWorkerConfiguration;
 import io.dropwizard.lifecycle.Managed;
 import lombok.extern.slf4j.Slf4j;
 import redis.clients.jedis.Jedis;
@@ -19,22 +17,20 @@ import static com.flipkart.drift.commons.utils.Constants.Workflow.DSL_UPDATE_CHA
 
 @Slf4j
 public class RedisCacheInvalidator implements Managed {
-    public static final String NODE_EVENT_ID = "NODE";
-    public static final String WORKFLOW_EVENT_ID = "WORKFLOW";
 
-    private final NodeDefinitionCache nodeDefinitionCache;
-    private final WorkflowCache workflowCache;
-    private final JedisPoolAbstract jedisPool;
+    private final DslCacheManager dslCacheManager;
+    private final boolean redisEnabled;
     private final ExecutorService executorService;
-    private volatile boolean running = false;  
-    
+    private volatile boolean running = false;
+
+    @Inject(optional = true)
+    private JedisPoolAbstract jedisPool;
+
     @Inject
-    public RedisCacheInvalidator(NodeDefinitionCache nodeDefinitionCache,
-                                 WorkflowCache workflowCache,
-                                 JedisPoolAbstract jedisPool) {
-        this.nodeDefinitionCache = nodeDefinitionCache;
-        this.workflowCache = workflowCache;
-        this.jedisPool = jedisPool;
+    public RedisCacheInvalidator(DslCacheManager dslCacheManager,
+                                 DriftWorkerConfiguration driftWorkerConfiguration) {
+        this.dslCacheManager = dslCacheManager;
+        this.redisEnabled = driftWorkerConfiguration.getRedisConfiguration().isRedisEnabled();
         this.executorService = Executors.newSingleThreadExecutor(
                 new ThreadFactoryBuilder()
                         .setNameFormat("redis-subscriber-%d")
@@ -45,6 +41,14 @@ public class RedisCacheInvalidator implements Managed {
 
     @Override
     public void start() throws Exception {
+        if (!redisEnabled) {
+            log.info("Redis is disabled (redisEnabled=false), skipping cache invalidation subscription");
+            return;
+        }
+        if (jedisPool == null) {
+            log.warn("Redis pool is null despite redisEnabled=true, skipping cache invalidation subscription");
+            return;
+        }
         try {
             log.info("Starting Redis cache invalidation listener");
             running = true;
@@ -57,20 +61,13 @@ public class RedisCacheInvalidator implements Managed {
                             public void onMessage(String channel, String message) {
                                 try {
                                     log.info("Received cache invalidation message: {}", message);
-                                /*
-                                    message is of format : NODE <rowKey> or NODE ALL or WORKFLOW <rowKey> or WORKFLOW ALL
-                                */
+                                    // message format: NODE <rowKey> | NODE ALL | WORKFLOW <rowKey> | WORKFLOW ALL
                                     String[] parts = message.split(" ", 2);
-                                    EntityVersionedCache<?> cache = getCache(parts[0]);
-                                    if (cache != null) {
-                                        if (parts[1].equals("ALL")) {
-                                            cache.invalidateAll();
-                                        } else {
-                                            cache.invalidate(parts[1]);
-                                        }
-                                    } else {
-                                        log.warn("Unknown cache type: {}, ignoring msg {}", parts[0], message);
+                                    if (parts.length < 2) {
+                                        log.warn("Malformed cache invalidation message: {}", message);
+                                        return;
                                     }
+                                    dslCacheManager.invalidate(parts[0], parts[1]);
                                 } catch (Exception e) {
                                     log.error("Error processing cache invalidation message", e);
                                 }
@@ -102,18 +99,6 @@ public class RedisCacheInvalidator implements Managed {
             });
         } catch (Exception e) {
             log.error("Failure starting Redis cache invalidation listener", e);
-        }
-    }
-
-    private EntityVersionedCache<?> getCache(String dslId) {
-        switch (dslId) {
-            case NODE_EVENT_ID:
-                return nodeDefinitionCache;
-            case WORKFLOW_EVENT_ID:
-                return workflowCache;
-            default:
-                log.warn("Unknown cache type: {}", dslId);
-                return null;
         }
     }
 

--- a/worker/src/main/java/com/flipkart/drift/worker/bootstrap/WorkerApplication.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/bootstrap/WorkerApplication.java
@@ -2,6 +2,7 @@ package com.flipkart.drift.worker.bootstrap;
 
 import com.flipkart.drift.persistence.bootstrap.DriftEntityModule;
 import com.flipkart.drift.persistence.dao.ConnectionType;
+import com.flipkart.drift.worker.task.CacheInvalidationTask;
 import com.flipkart.drift.worker.util.AuthNTokenGenerator;
 import com.flipkart.drift.worker.config.DriftWorkerConfiguration;
 import com.flipkart.drift.worker.resources.DriftWorkerResource;
@@ -98,6 +99,7 @@ public class WorkerApplication extends Application<DriftWorkerConfiguration> {
         environment.lifecycle().manage(new TemporalWorkerManaged(injector, driftWorkerConfiguration, metricsScope));
         environment.lifecycle().manage(injector.getInstance(RedisCacheInvalidator.class));
         environment.jersey().register(injector.getInstance(DriftWorkerResource.class));
+        environment.admin().addTask(injector.getInstance(CacheInvalidationTask.class));
     }
 
     private static ConcurrentCompositeConfiguration getConcurrentCompositeConfiguration(DriftWorkerConfiguration configuration) {

--- a/worker/src/main/java/com/flipkart/drift/worker/bootstrap/WorkerModule.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/bootstrap/WorkerModule.java
@@ -52,8 +52,12 @@ public class WorkerModule extends AbstractModule {
     }
 
     private JedisSentinelPool provideJedisPool() {
+        final RedisConfiguration redisConfiguration = driftWorkerConfiguration.getRedisConfiguration();
+        if (!redisConfiguration.isRedisEnabled()) {
+            log.info("Redis is disabled (redisEnabled=false), skipping JedisSentinelPool creation");
+            return null;
+        }
         try {
-            final RedisConfiguration redisConfiguration = driftWorkerConfiguration.getRedisConfiguration();
             String hosts = redisConfiguration.getSentinels();
             StringTokenizer strTkn = new StringTokenizer(hosts, ",");
             List<String> hostList = new ArrayList<>();
@@ -167,7 +171,11 @@ public class WorkerModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        bind(JedisPoolAbstract.class).toInstance(this.jedisSentinelPool);
+        if (this.jedisSentinelPool != null) {
+            bind(JedisPoolAbstract.class).toInstance(this.jedisSentinelPool);
+        }
+        // When jedisSentinelPool is null (Redis disabled), JedisPoolAbstract is unbound.
+        // Classes using @Inject(optional=true) field injection will receive null gracefully.
         bind(DriftWorkerConfiguration.class).toInstance(driftWorkerConfiguration);
         bind(StringResolver.class).to(MustacheStringResolver.class);
         bind(Connection.class).annotatedWith(Names.named(ConnectionType.HOT.name())).toProvider(ConnectionProviderWorker.class).asEagerSingleton();

--- a/worker/src/main/java/com/flipkart/drift/worker/config/RedisConfiguration.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/config/RedisConfiguration.java
@@ -18,5 +18,6 @@ public class RedisConfiguration {
     private int maxWaitMillis;
     private boolean testOnBorrow;
     private boolean blockWhenExhausted;
+    private boolean redisEnabled = true;
     private int database;
 }

--- a/worker/src/main/java/com/flipkart/drift/worker/model/activity/ActivityResponse.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/model/activity/ActivityResponse.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.io.Serializable;
 
@@ -13,6 +14,7 @@ import java.io.Serializable;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Setter
 public class ActivityResponse implements Serializable {
     private WorkflowStatus workflowStatus;
     private JsonNode nodeResponse;

--- a/worker/src/main/java/com/flipkart/drift/worker/task/CacheInvalidationTask.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/task/CacheInvalidationTask.java
@@ -1,0 +1,56 @@
+package com.flipkart.drift.worker.task;
+
+import com.flipkart.drift.worker.bootstrap.DslCacheManager;
+import com.google.inject.Inject;
+import io.dropwizard.servlets.tasks.Task;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Dropwizard admin task for DNS-fanout based cache invalidation.
+ * Registered on the admin port so the API can POST to each worker pod directly
+ * when Redis pub-sub is unavailable.
+ *
+ * Usage:
+ *   POST /tasks/cache-invalidate?type=NODE&key=<rowKey>
+ *   POST /tasks/cache-invalidate?type=WORKFLOW&key=<rowKey>
+ *   POST /tasks/cache-invalidate?type=NODE&key=ALL   (invalidates entire cache)
+ */
+@Slf4j
+public class CacheInvalidationTask extends Task {
+
+    private final DslCacheManager dslCacheManager;
+
+    @Inject
+    public CacheInvalidationTask(DslCacheManager dslCacheManager) {
+        super("cache-invalidate");
+        this.dslCacheManager = dslCacheManager;
+    }
+
+    @Override
+    public void execute(Map<String, List<String>> parameters, PrintWriter output) throws Exception {
+        String type = getFirst(parameters, "type");
+        String key = getFirst(parameters, "key");
+
+        if (type == null || key == null) {
+            output.println("ERROR: required params: type (NODE|WORKFLOW), key (<rowKey> or ALL)");
+            return;
+        }
+
+        log.info("Cache invalidation task invoked: type={}, key={}", type, key);
+        boolean found = dslCacheManager.invalidate(type, key);
+        if (found) {
+            output.println("OK: invalidated type=" + type + " key=" + key);
+        } else {
+            output.println("ERROR: unknown cache type: " + type + " (expected NODE or WORKFLOW)");
+        }
+    }
+
+    private String getFirst(Map<String, List<String>> params, String name) {
+        List<String> values = params.get(name);
+        return (values == null || values.isEmpty()) ? null : values.get(0);
+    }
+}

--- a/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
@@ -21,6 +21,9 @@ import org.slf4j.Logger;
 
 import java.util.Map;
 
+import static com.flipkart.drift.worker.util.Constants.VERSION;
+import static com.flipkart.drift.worker.util.Constants.WORKFLOW_ID;
+
 @Data
 @Slf4j
 public class GenericWorkflowImpl implements com.flipkart.drift.workflows.GenericWorkflow {
@@ -42,7 +45,7 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
             Workflow workflow = fetchDsl(workflowStartRequest);
             if (workflow == null) {
                 throw ApplicationFailure.newNonRetryableFailure(
-                        "Workflow not found for issue: " + workflowStartRequest.getIssueDetail().getIssueId(),
+                        "Workflow not found for issueId: " + safeIssueId(workflowStartRequest),
                         "WORKFLOW_NOT_FOUND"
                 );
             }
@@ -122,27 +125,60 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
         this.workflowState.setWorkflowId(io.temporal.workflow.Workflow.getInfo().getWorkflowId());
         this.workflowState.setStatus(WorkflowStatus.CREATED);
         this.workflowState.setIssueDetail(workflowStartRequest.getIssueDetail());
+        // Capture explicit DSL identity so disconnected nodes can resolve without issueId.
+        if (workflowStartRequest.getParams() != null) {
+            Object dslWorkflowId = workflowStartRequest.getParams().get(WORKFLOW_ID);
+            Object dslVersion = workflowStartRequest.getParams().get(VERSION);
+            if (dslWorkflowId != null && dslVersion != null) {
+                this.workflowState.setWorkflowDslId(dslWorkflowId.toString());
+                this.workflowState.setWorkflowVersion(dslVersion.toString());
+            }
+        }
         io.temporal.workflow.Workflow.newActivityStub(WorkflowContextManagerActivity.class, OptionsStore.activityOptions)
                 .persistWorkflowState(workflowStartRequest, io.temporal.workflow.Workflow.getInfo().getWorkflowId());
     }
 
     private Workflow fetchDsl(WorkflowStartRequest workflowRequest) {
-        log.info("Fetching workflow DSL for issueId: {}", workflowRequest.getIssueDetail().getIssueId());
+        log.info("Fetching workflow DSL for issueId: {}", safeIssueId(workflowRequest));
         FetchWorkflowActivity fetchWorkflowActivity = io.temporal.workflow.Workflow.newActivityStub(
                 FetchWorkflowActivity.class, OptionsStore.activityOptions);
         return fetchWorkflowActivity.fetchWorkflowBasedOnRequest(workflowRequest);
 
     }
 
+    private static String safeIssueId(WorkflowStartRequest request) {
+        return request != null && request.getIssueDetail() != null
+                ? request.getIssueDetail().getIssueId() : null;
+    }
+
     @Timed(name = "workflow.execute.disconnected.duration")
     @Override
     public WorkflowUtilityResponse executeDisconnectedNode(WorkflowUtilityRequest workflowUtilityRequest) {
         String tenant = workflowUtilityRequest.getThreadContext().getOrDefault("tenant", "fk");
-        WorkflowNode workflowNode = io.temporal.workflow.Workflow.newActivityStub(
-                FetchWorkflowActivity.class,
-                OptionsStore.activityOptions).fetchWorkflowNode(
-                this.workflowState.getIssueDetail().getIssueId(),
-                workflowUtilityRequest.getNode(), tenant);
+        FetchWorkflowActivity fetchWorkflowActivity = io.temporal.workflow.Workflow.newActivityStub(
+                FetchWorkflowActivity.class, OptionsStore.activityOptions);
+        String node = workflowUtilityRequest.getNode();
+
+        String issueId = this.workflowState.getIssueDetail() != null
+                ? this.workflowState.getIssueDetail().getIssueId() : null;
+
+        WorkflowNode workflowNode;
+        if (issueId != null && !issueId.trim().isEmpty()) {
+            // Backward-compatible path: resolve via issue mapping.
+            workflowNode = fetchWorkflowActivity.fetchWorkflowNode(issueId, node, tenant);
+        } else if (this.workflowState.getWorkflowDslId() != null
+                && this.workflowState.getWorkflowVersion() != null) {
+            // issueId-free path: resolve directly via the workflow DSL identity captured at start.
+            Workflow workflow = fetchWorkflowActivity.fetchWorkflow(
+                    this.workflowState.getWorkflowDslId(),
+                    this.workflowState.getWorkflowVersion(), tenant);
+            workflowNode = workflow.getStates().get(node);
+        } else {
+            throw ApplicationFailure.newNonRetryableFailure(
+                    "Cannot execute disconnected node: workflow has neither issueId nor workflowId/version.",
+                    "WORKFLOW_RESOLUTION_FAILED"
+            );
+        }
         return nodeExecutor.executeWorkflowNode(workflowUtilityRequest, workflowNode);
     }
 }

--- a/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
@@ -159,25 +159,27 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
                 FetchWorkflowActivity.class, OptionsStore.activityOptions);
         String node = workflowUtilityRequest.getNode();
 
-        String issueId = this.workflowState.getIssueDetail() != null
-                ? this.workflowState.getIssueDetail().getIssueId() : null;
-
         WorkflowNode workflowNode;
-        if (issueId != null && !issueId.trim().isEmpty()) {
-            // Backward-compatible path: resolve via issue mapping.
-            workflowNode = fetchWorkflowActivity.fetchWorkflowNode(issueId, node, tenant);
-        } else if (this.workflowState.getWorkflowDslId() != null
+        if (this.workflowState.getWorkflowDslId() != null
                 && this.workflowState.getWorkflowVersion() != null) {
-            // issueId-free path: resolve directly via the workflow DSL identity captured at start.
+            // Preferred path: resolve directly via the workflow DSL identity captured at start.
+            // Kept consistent with FetchWorkflowActivityImpl#fetchWorkflowBasedOnRequest, which
+            // also prefers params.workflowId/version over issueId.
             Workflow workflow = fetchWorkflowActivity.fetchWorkflow(
                     this.workflowState.getWorkflowDslId(),
                     this.workflowState.getWorkflowVersion(), tenant);
             workflowNode = workflow.getStates().get(node);
         } else {
-            throw ApplicationFailure.newNonRetryableFailure(
-                    "Cannot execute disconnected node: workflow has neither issueId nor workflowId/version.",
-                    "WORKFLOW_RESOLUTION_FAILED"
-            );
+            String issueId = this.workflowState.getIssueDetail() != null
+                    ? this.workflowState.getIssueDetail().getIssueId() : null;
+            if (issueId == null || issueId.trim().isEmpty()) {
+                throw ApplicationFailure.newNonRetryableFailure(
+                        "Cannot execute disconnected node: workflow has neither workflowId/version nor issueId.",
+                        "WORKFLOW_RESOLUTION_FAILED"
+                );
+            }
+            // Backward-compatible fallback: resolve via issue mapping.
+            workflowNode = fetchWorkflowActivity.fetchWorkflowNode(issueId, node, tenant);
         }
         return nodeExecutor.executeWorkflowNode(workflowUtilityRequest, workflowNode);
     }

--- a/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.annotation.Timed;
 import com.flipkart.drift.worker.activities.FetchWorkflowActivity;
 import com.flipkart.drift.worker.activities.WorkflowContextManagerActivity;
 import com.flipkart.drift.worker.model.activity.ActivityThinResponse;
+import com.flipkart.drift.sdk.model.enums.WorkflowExecutionMode;
 import com.flipkart.drift.sdk.model.request.WorkflowResumeRequest;
 import com.flipkart.drift.sdk.model.request.WorkflowStartRequest;
 import com.flipkart.drift.sdk.model.request.WorkflowTerminateRequest;
@@ -122,6 +123,11 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
         this.workflowState.setWorkflowId(io.temporal.workflow.Workflow.getInfo().getWorkflowId());
         this.workflowState.setStatus(WorkflowStatus.CREATED);
         this.workflowState.setIssueDetail(workflowStartRequest.getIssueDetail());
+        this.workflowState.setWorkflowExecutionMode(
+                workflowStartRequest.getWorkflowExecutionMode() != null
+                        ? workflowStartRequest.getWorkflowExecutionMode()
+                        : WorkflowExecutionMode.SYNC
+        );
         io.temporal.workflow.Workflow.newActivityStub(WorkflowContextManagerActivity.class, OptionsStore.activityOptions)
                 .persistWorkflowState(workflowStartRequest, io.temporal.workflow.Workflow.getInfo().getWorkflowId());
     }

--- a/worker/src/main/java/com/flipkart/drift/worker/workflows/WorkflowNodeExecutor.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/workflows/WorkflowNodeExecutor.java
@@ -1,6 +1,7 @@
 package com.flipkart.drift.worker.workflows;
 
 import com.flipkart.drift.commons.model.enums.ExecutionMode;
+import com.flipkart.drift.sdk.model.enums.WorkflowExecutionMode;
 import com.flipkart.drift.commons.model.node.ChildNode;
 import com.flipkart.drift.sdk.model.request.WorkflowStartRequest;
 import com.flipkart.drift.worker.activities.ReturnControlActivity;
@@ -184,7 +185,10 @@ public class WorkflowNodeExecutor {
 
     private void handleWaitingState(String workflowId, ActivityThinResponse activityThinResponse) {
         this.workflowState.setView(activityThinResponse.getView());
-        io.temporal.workflow.Workflow.newActivityStub(ReturnControlActivity.class, OptionsStore.activityOptions).exec(workflowId);
+        // Notify API via Redis only in SYNC mode; ASYNC workflows don't block the API thread
+        if (workflowState.getWorkflowExecutionMode() != WorkflowExecutionMode.ASYNC) {
+            io.temporal.workflow.Workflow.newActivityStub(ReturnControlActivity.class, OptionsStore.activityOptions).exec(workflowId);
+        }
         io.temporal.workflow.Workflow.await(() -> {
             WorkflowStatus status = this.workflowState.getStatus();
             return !(status.equals(WorkflowStatus.WAITING) || status.equals(WorkflowStatus.TERMINATED));
@@ -211,7 +215,9 @@ public class WorkflowNodeExecutor {
         if (activityThinResponse.getErrorResponse() != null) {
             this.workflowState.setErrorMessage(activityThinResponse.getErrorResponse().asText());
         }
-        io.temporal.workflow.Workflow.newActivityStub(ReturnControlActivity.class, OptionsStore.activityOptions).exec(workflowId);
+        if (workflowState.getWorkflowExecutionMode() != WorkflowExecutionMode.ASYNC) {
+            io.temporal.workflow.Workflow.newActivityStub(ReturnControlActivity.class, OptionsStore.activityOptions).exec(workflowId);
+        }
         throw ApplicationFailure.newNonRetryableFailure(
                 "Encountered a failure node",
                 "FAILURE_NODE"
@@ -221,7 +227,9 @@ public class WorkflowNodeExecutor {
     private void handleCompletedState(String workflowId, ActivityThinResponse activityThinResponse, Workflow workflow, Map<String, String> threadContext) {
         this.workflowState.setView(activityThinResponse.getView());
         this.workflowState.setDisposition(activityThinResponse.getDisposition());
-        io.temporal.workflow.Workflow.newActivityStub(ReturnControlActivity.class, OptionsStore.activityOptions).exec(workflowId);
+        if (workflowState.getWorkflowExecutionMode() != WorkflowExecutionMode.ASYNC) {
+            io.temporal.workflow.Workflow.newActivityStub(ReturnControlActivity.class, OptionsStore.activityOptions).exec(workflowId);
+        }
 
         // Execute post-workflow completion nodes if they exist
         if (workflow != null && workflow.getPostWorkflowCompletionNodes() != null && !workflow.getPostWorkflowCompletionNodes().isEmpty()) {
@@ -248,8 +256,10 @@ public class WorkflowNodeExecutor {
     }
 
     private void handleDelegatedState(String workflowId, ActivityThinResponse activityThinResponse) {
-        io.temporal.workflow.Workflow.newActivityStub(ReturnControlActivity.class, OptionsStore.activityOptions)
-                .exec(workflowId);
+        if (workflowState.getWorkflowExecutionMode() != WorkflowExecutionMode.ASYNC) {
+            io.temporal.workflow.Workflow.newActivityStub(ReturnControlActivity.class, OptionsStore.activityOptions)
+                    .exec(workflowId);
+        }
     }
 
     private void updateWorkflowState(ActivityThinResponse response, WorkflowNode currentNode) {

--- a/worker/src/main/resources/config/configuration.yaml
+++ b/worker/src/main/resources/config/configuration.yaml
@@ -19,6 +19,7 @@ redisConfiguration:
   minIdle: 25
   testOnBorrow: true
   blockWhenExhausted: true
+  redisEnabled: ${REDIS_ENABLED:true}  # override via env var; defaults to true for backward compatibility
 
 cacheRefreshExecutorServiceConfig:
   minThreads: 1


### PR DESCRIPTION
**PR Description — What changed and why**

Problem

issueDetail was @NotNull — so callers like the IRN flow (which knows the workflowId directly and has no concept of an "issue") were forced to send a dummy issueDetail object even though it served no purpose for them.

What was changed (4 files)

**1. WorkflowStartRequest.java**
Removed @NotNull from issueDetail. Marked it @Deprecated. It's now optional — callers who don't have an issue context no longer need to send it.

**2. FetchWorkflowActivityImpl.java**
Added a preferred resolution path: if params.workflowId + params.version are present, use them directly to fetch the workflow DSL — no issueDetail needed. Falls back to the old issueDetail.issueId → issue-workflow mapping path for existing callers. Throws a clear, actionable error if neither is provided.

**3. GenericWorkflowImpl.java**
Made all issueDetail accesses null-safe. Also saves workflowDslId + workflowVersion on WorkflowState at workflow start — so disconnected node execution can resolve the workflow DSL even when issueDetail is absent.

**4. WorkflowState.java**
Added two new fields: workflowDslId and workflowVersion. Purely additive — these get populated when the workflow is started via params.workflowId/version and are used later by disconnected node execution.

Why it's safe

- All existing callers passing issueDetail continue to work unchanged (fallback path preserved)
- No silent failures — if neither resolution path is available, a clear exception is thrown
- Disconnected node execution is also covered via the new fields on WorkflowState

**Testing Results**
<img width="1880" height="1328" alt="image" src="https://github.com/user-attachments/assets/b8cba5e4-d343-46fe-8f4a-9ccc597c8943" />
<img width="1852" height="1392" alt="image" src="https://github.com/user-attachments/assets/c65c3e58-ec1d-4531-a543-79516c013075" />

 Note: When neither issueDetail nor params.workflowId/version is provided, the activity throws an IllegalArgumentException with a descriptive message. Temporal currently retries this (causing API timeout) rather than failing fast. Making this exception non-retryable (ApplicationFailure.newNonRetryableFailure) is a follow-up improvement and is out of scope for this change — the primary goal of this PR is making issueDetail optional for callers who resolve workflows via params.workflowId.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added synchronous and asynchronous workflow execution, including immediate responses for asynchronous starts.
  * Added business-key idempotency with replay detection and response headers.
  * Added Redis-optional cache invalidation with DNS-based worker fanout and configurable Kubernetes support.

* **Improvements**
  * Improved workflow identification and validation for legacy and parameter-based requests.
  * Improved handling of missing workflow details and terminal or waiting statuses.

* **Documentation**
  * Documented idempotency headers, replay behavior, execution modes, and backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->