### PR TITLE
RPROC-18991 | Error_Unsideline 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ logs/
 /do-not-commit
 *-secret*
 *-secrets*
+*-credentials
 *.key
 *.pem
 .cursor

--- a/api/src/main/java/com/flipkart/drift/api/client/CacheInvalidationClient.java
+++ b/api/src/main/java/com/flipkart/drift/api/client/CacheInvalidationClient.java
@@ -1,0 +1,91 @@
+package com.flipkart.drift.api.client;
+
+import com.flipkart.drift.api.config.DriftConfiguration;
+import com.flipkart.drift.api.config.WorkerInvalidationConfig;
+import lombok.extern.slf4j.Slf4j;
+import redis.clients.jedis.JedisSentinelPool;
+
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.URL;
+
+import static com.flipkart.drift.api.service.utils.Utility.publishRedisEvent;
+import static com.flipkart.drift.commons.utils.Constants.Workflow.DSL_UPDATE_CHANNEL;
+
+/**
+ * Publishes DSL cache invalidation events to all worker pods.
+ * Strategy:
+ *   - Redis enabled and pool available → publish to DSL_UPDATE_CHANNEL (existing behaviour).
+ *   - Redis disabled → DNS fanout: resolve K8s headless service → POST to each worker pod's admin task endpoint.
+ */
+@Slf4j
+public class CacheInvalidationClient {
+
+    private final boolean redisEnabled;
+    private final JedisSentinelPool jedisSentinelPool;
+    private final WorkerInvalidationConfig workerInvalidationConfig;
+
+    public CacheInvalidationClient(DriftConfiguration driftConfiguration, JedisSentinelPool jedisSentinelPool) {
+        this.redisEnabled = driftConfiguration.getRedisConfiguration().isRedisEnabled();
+        this.jedisSentinelPool = jedisSentinelPool;
+        this.workerInvalidationConfig = driftConfiguration.getWorkerInvalidationConfig();
+    }
+
+    /**
+     * Invalidates the cache entry for the given key on all worker pods.
+     *
+     * @param cacheType  "NODE" or "WORKFLOW"
+     * @param key        HBase row key to invalidate, or "ALL"
+     */
+    public void invalidate(String cacheType, String key) {
+        if (redisEnabled && jedisSentinelPool != null) {
+            publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, cacheType + " " + key);
+        } else {
+            log.info("Redis unavailable; using DNS fanout for cache invalidation: type={}, key={}", cacheType, key);
+            fanoutToWorkers(cacheType, key);
+        }
+    }
+
+    private void fanoutToWorkers(String cacheType, String key) {
+        if (workerInvalidationConfig == null || !workerInvalidationConfig.isEnabled()
+                || workerInvalidationConfig.getHeadlessServiceHost() == null
+                || workerInvalidationConfig.getHeadlessServiceHost().isBlank()) {
+            log.debug("Worker invalidation config not set or disabled, skipping fanout");
+            return;
+        }
+        fanout(workerInvalidationConfig.getHeadlessServiceHost(),
+                workerInvalidationConfig.getAdminPort(),
+                workerInvalidationConfig.getPerPodTimeoutMs(),
+                cacheType, key);
+    }
+
+    private void fanout(String headlessServiceHost, int adminPort, int timeoutMs,
+                        String cacheType, String key) {
+        try {
+            InetAddress[] addresses = InetAddress.getAllByName(headlessServiceHost);
+            log.info("DNS fanout to {} worker pod(s) for cache type={} key={}", addresses.length, cacheType, key);
+            for (InetAddress address : addresses) {
+                postInvalidation(address.getHostAddress(), adminPort, timeoutMs, cacheType, key);
+            }
+        } catch (Exception e) {
+            log.error("Error during DNS fanout to workers for cache type={} key={}", cacheType, key, e);
+        }
+    }
+
+    private void postInvalidation(String ip, int port, int timeoutMs, String cacheType, String key) {
+        String urlStr = String.format("http://%s:%d/tasks/cache-invalidate?type=%s&key=%s", ip, port, cacheType, key);
+        try {
+            URL url = new URL(urlStr);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setConnectTimeout(timeoutMs);
+            conn.setReadTimeout(timeoutMs);
+            conn.setDoOutput(true);
+            int responseCode = conn.getResponseCode();
+            conn.disconnect();
+            log.debug("Cache invalidation POST to {} returned {}", urlStr, responseCode);
+        } catch (Exception e) {
+            log.error("Failed to POST cache invalidation to {}: {}", urlStr, e.getMessage());
+        }
+    }
+}

--- a/api/src/main/java/com/flipkart/drift/api/config/DriftConfiguration.java
+++ b/api/src/main/java/com/flipkart/drift/api/config/DriftConfiguration.java
@@ -31,5 +31,8 @@ public class DriftConfiguration extends Configuration {
     private String hadoopUserName;
     @NotNull
     private String hadoopLoginUser;
+
+    /** Config for DNS-fanout cache invalidation to worker pods (used when redisEnabled=false). */
+    private WorkerInvalidationConfig workerInvalidationConfig;
 }
 

--- a/api/src/main/java/com/flipkart/drift/api/config/RedisConfiguration.java
+++ b/api/src/main/java/com/flipkart/drift/api/config/RedisConfiguration.java
@@ -18,6 +18,7 @@ public class RedisConfiguration {
     private int maxWaitMillis;
     private boolean testOnBorrow;
     private boolean blockWhenExhausted;
+    private boolean redisEnabled = true;
 }
 
 

--- a/api/src/main/java/com/flipkart/drift/api/config/WorkerInvalidationConfig.java
+++ b/api/src/main/java/com/flipkart/drift/api/config/WorkerInvalidationConfig.java
@@ -1,0 +1,25 @@
+package com.flipkart.drift.api.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Configuration for DNS-fanout cache invalidation to worker pods.
+ * Used when Redis pub-sub is unavailable (redisEnabled=false).
+ * Set headlessServiceHost to a K8s headless service DNS name;
+ * InetAddress.getAllByName() will resolve it to all pod IPs.
+ */
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WorkerInvalidationConfig {
+    /** K8s headless service DNS name for workers (resolves to all pod IPs). */
+    private String headlessServiceHost;
+    /** Dropwizard admin port on worker pods (matches adminConnectors port in worker config). */
+    private int adminPort = 5601;
+    /** Per-pod HTTP connect+read timeout in milliseconds. */
+    private int perPodTimeoutMs = 2000;
+    /** Set to false to suppress fanout even when Redis is disabled. */
+    private boolean enabled = true;
+}

--- a/api/src/main/java/com/flipkart/drift/api/module/WorkflowClientModule.java
+++ b/api/src/main/java/com/flipkart/drift/api/module/WorkflowClientModule.java
@@ -1,6 +1,7 @@
 package com.flipkart.drift.api.module;
 
 import com.codahale.metrics.MetricRegistry;
+import com.flipkart.drift.api.client.CacheInvalidationClient;
 import com.flipkart.drift.api.config.DriftConfiguration;
 import com.flipkart.drift.persistence.dao.ConnectionType;
 import com.flipkart.drift.persistence.dao.IConnectionProvider;
@@ -9,6 +10,7 @@ import com.flipkart.drift.api.config.RedisConfiguration;
 import com.flipkart.drift.api.exception.mapper.ApiExceptionMapper;
 import com.google.inject.*;
 import com.google.inject.name.Names;
+import javax.annotation.Nullable;
 import com.netflix.config.DynamicProperty;
 import io.dropwizard.setup.Environment;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +42,10 @@ public class WorkflowClientModule extends AbstractModule {
     }
 
     private JedisSentinelPool provideJedisPool() {
+        if (!redisConfiguration.isRedisEnabled()) {
+            log.info("Redis is disabled (redisEnabled=false), skipping JedisSentinelPool creation");
+            return null;
+        }
         try {
             final RedisConfiguration redisConfiguration = this.redisConfiguration;
             String hosts = redisConfiguration.getSentinels();
@@ -53,8 +59,6 @@ public class WorkflowClientModule extends AbstractModule {
         } catch (Exception e) {
             log.error("Failed to Connected to RedisDao Server {}", e.getMessage(), e);
             return null;
-            // TODO : Clean this up ... Change made so that bootstrap shouldn't be failing on redis failure
-//            throw new RedisStoreException(Response.Status.INTERNAL_SERVER_ERROR, "Unable to init redis config", e.getMessage());
         }
     }
 
@@ -170,6 +174,7 @@ public class WorkflowClientModule extends AbstractModule {
 
     @Provides
     @Singleton
+    @Nullable
     public JedisSentinelPool getJedisSentinelPool() {
         return this.jedisSentinelPool;
     }
@@ -178,6 +183,12 @@ public class WorkflowClientModule extends AbstractModule {
     @Singleton
     public DriftConfiguration getDriftConfiguration() {
         return this.driftConfiguration;
+    }
+
+    @Provides
+    @Singleton
+    public CacheInvalidationClient getCacheInvalidationClient() {
+        return new CacheInvalidationClient(this.driftConfiguration, this.jedisSentinelPool);
     }
 
 }

--- a/api/src/main/java/com/flipkart/drift/api/resources/WorkflowResource.java
+++ b/api/src/main/java/com/flipkart/drift/api/resources/WorkflowResource.java
@@ -50,9 +50,9 @@ public class WorkflowResource {
     @Timed
     @Path("/workflow/{workflowId}/node/{nodeId}/resume")
     @ExceptionMetered
-    public Response resumeNode(@NotEmpty @PathParam("workflowId") String workflowId,
+    public Response unsidelineWorkflow(@NotEmpty @PathParam("workflowId") String workflowId,
                                @NotEmpty @PathParam("nodeId") String nodeId) {
-        temporalService.resumeNode(workflowId, nodeId);
+        temporalService.unsidelineWorkflow(workflowId, nodeId);
         return Response.ok().build();
     }
 

--- a/api/src/main/java/com/flipkart/drift/api/resources/WorkflowResource.java
+++ b/api/src/main/java/com/flipkart/drift/api/resources/WorkflowResource.java
@@ -46,6 +46,16 @@ public class WorkflowResource {
         return temporalService.resumeWorkflow(workflowResumeRequest);
     }
 
+    @PUT
+    @Timed
+    @Path("/workflow/{workflowId}/node/{nodeId}/resume")
+    @ExceptionMetered
+    public Response resumeNode(@NotEmpty @PathParam("workflowId") String workflowId,
+                               @NotEmpty @PathParam("nodeId") String nodeId) {
+        temporalService.resumeNode(workflowId, nodeId);
+        return Response.ok().build();
+    }
+
     @DELETE
     @Timed
     @Path("/workflow/terminate/{workflowId}")

--- a/api/src/main/java/com/flipkart/drift/api/resources/WorkflowResource.java
+++ b/api/src/main/java/com/flipkart/drift/api/resources/WorkflowResource.java
@@ -48,7 +48,7 @@ public class WorkflowResource {
 
     @PUT
     @Timed
-    @Path("/workflow/{workflowId}/node/{nodeId}/resume")
+    @Path("/workflow/{workflowId}/node/{nodeId}/unsideline")
     @ExceptionMetered
     public Response unsidelineWorkflow(@NotEmpty @PathParam("workflowId") String workflowId,
                                @NotEmpty @PathParam("nodeId") String nodeId) {

--- a/api/src/main/java/com/flipkart/drift/api/service/RedisPubSubService.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/RedisPubSubService.java
@@ -5,6 +5,7 @@ import com.codahale.metrics.Timer;
 import com.flipkart.drift.api.exception.ApiException;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import javax.annotation.Nullable;
 import io.dropwizard.lifecycle.Managed;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -27,7 +28,7 @@ public class RedisPubSubService implements Managed {
     private final ExecutorService redisThreadPool;
 
     @Inject
-    public RedisPubSubService(JedisSentinelPool jedisSentinelPool) {
+    public RedisPubSubService(@Nullable JedisSentinelPool jedisSentinelPool) {
         this.jedisSentinelPool = jedisSentinelPool;
         this.redisThreadPool = new ThreadPoolExecutor(
                 10, 50,
@@ -39,6 +40,10 @@ public class RedisPubSubService implements Managed {
     }
 
     private void publishGaugeMetrics() {
+        if (jedisSentinelPool == null) {
+            log.info("Redis pool is null (Redis disabled), skipping Jedis gauge registration");
+            return;
+        }
         // Monitor jedis pool metrics
         registerGauge(
                 this.getClass(),

--- a/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
@@ -110,10 +110,10 @@ public class TemporalService {
         }
     }
 
-    public void resumeNode(String workflowId, String nodeId) {
+    public void unsidelineWorkflow(String workflowId, String nodeId) {
         try {
             GenericWorkflow workflow = client.newWorkflowStub(GenericWorkflow.class, workflowId);
-            workflow.resumeNode(nodeId);
+            workflow.unsidelineWorkflow(nodeId);
         } catch (WorkflowNotFoundException e) {
             throw new ApiException(Response.Status.NOT_FOUND, e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
         } catch (WorkflowException e) {

--- a/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
@@ -3,6 +3,7 @@ package com.flipkart.drift.api.service;
 import com.flipkart.drift.api.config.DriftConfiguration;
 import com.flipkart.drift.api.filters.RequestThreadContext;
 import com.flipkart.drift.api.exception.ApiException;
+import com.flipkart.drift.sdk.model.enums.WorkflowExecutionMode;
 import com.flipkart.drift.sdk.model.request.WorkflowResumeRequest;
 import com.flipkart.drift.sdk.model.request.WorkflowStartRequest;
 import com.flipkart.drift.sdk.model.request.WorkflowTerminateRequest;
@@ -10,6 +11,7 @@ import com.flipkart.drift.sdk.model.request.WorkflowUtilityRequest;
 import com.flipkart.drift.sdk.model.response.View;
 import com.flipkart.drift.sdk.model.response.WorkflowResponse;
 import com.flipkart.drift.sdk.model.response.WorkflowUtilityResponse;
+import com.flipkart.drift.sdk.model.enums.WorkflowStatus;
 import com.flipkart.drift.commons.model.temporal.WorkflowState;
 import com.flipkart.drift.api.service.utils.Utility;
 import com.flipkart.drift.workflows.GenericWorkflow;
@@ -63,6 +65,10 @@ public class TemporalService {
 
     public WorkflowResponse executeWorkflow(WorkflowStartRequest workflowStartRequest) {
         String workflowId = workflowStartRequest.getWorkflowId();
+        WorkflowExecutionMode executionMode = workflowStartRequest.getWorkflowExecutionMode() != null
+                ? workflowStartRequest.getWorkflowExecutionMode()
+                : WorkflowExecutionMode.SYNC;
+
         GenericWorkflow workflow;
         try {
             workflow = client.newWorkflowStub(
@@ -74,11 +80,28 @@ public class TemporalService {
                             .setWorkflowIdReusePolicy(WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING)
                             .build()
             );
-            redisPubSubService.subscribeAndExecute(workflowId, () -> {
+
+            if (executionMode == WorkflowExecutionMode.ASYNC) {
                 WorkflowClient.start(workflow::startWorkflow, workflowStartRequest);
-                return null;
-            }, START);
-            return buildResponseAndReturn(workflow);
+                return WorkflowResponse.builder()
+                        .workflowId(workflowId)
+                        .workflowStatus(WorkflowStatus.RUNNING)
+                        .build();
+            } else {
+                // SYNC mode: block until workflow reaches a terminal state via Redis
+                if (!driftConfiguration.getRedisConfiguration().isRedisEnabled()) {
+                    throw new ApiException(Response.Status.BAD_REQUEST,
+                            "SYNC execution mode requires Redis to be enabled. " +
+                            "Set executionMode=ASYNC or enable Redis (redisEnabled=true).");
+                }
+                redisPubSubService.subscribeAndExecute(workflowId, () -> {
+                    WorkflowClient.start(workflow::startWorkflow, workflowStartRequest);
+                    return null;
+                }, START);
+                return buildResponseAndReturn(workflow);
+            }
+        } catch (ApiException e) {
+            throw e;
         } catch (WorkflowNotFoundException e) {
             throw new ApiException(Response.Status.NOT_FOUND, e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
         } catch (WorkflowException e) {
@@ -94,11 +117,23 @@ public class TemporalService {
         try {
             workflowResumeRequest.setThreadContext(RequestThreadContext.get().getLegacyThreadContext());
             GenericWorkflow workflow = client.newWorkflowStub(GenericWorkflow.class, workflowResumeRequest.getWorkflowId());
-            redisPubSubService.subscribeAndExecute(workflowResumeRequest.getWorkflowId(), () -> {
+
+            // Determine execution mode from the running workflow's persisted state
+            WorkflowState currentState = workflow.getWorkflowState();
+            WorkflowExecutionMode executionMode = currentState.getWorkflowExecutionMode() != null
+                    ? currentState.getWorkflowExecutionMode()
+                    : WorkflowExecutionMode.SYNC;
+
+            if (executionMode == WorkflowExecutionMode.ASYNC) {
                 workflow.resumeWorkflow(workflowResumeRequest);
-                return null;
-            }, RESUME);
-            return buildResponseAndReturn(workflow);
+                return buildResponseAndReturn(workflow);
+            } else {
+                redisPubSubService.subscribeAndExecute(workflowResumeRequest.getWorkflowId(), () -> {
+                    workflow.resumeWorkflow(workflowResumeRequest);
+                    return null;
+                }, RESUME);
+                return buildResponseAndReturn(workflow);
+            }
         } catch (WorkflowNotFoundException e) {
             throw new ApiException(Response.Status.NOT_FOUND, e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
         } catch (WorkflowException e) {
@@ -161,7 +196,3 @@ public class TemporalService {
                 .build();
     }
 }
-
-
-
-

--- a/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
@@ -110,6 +110,21 @@ public class TemporalService {
         }
     }
 
+    public void resumeNode(String workflowId, String nodeId) {
+        try {
+            GenericWorkflow workflow = client.newWorkflowStub(GenericWorkflow.class, workflowId);
+            workflow.resumeNode(nodeId);
+        } catch (WorkflowNotFoundException e) {
+            throw new ApiException(Response.Status.NOT_FOUND, e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
+        } catch (WorkflowException e) {
+            log.error(WORKFLOW_EXCEPTION, e.getMessage(), e);
+            throw new ApiException(Response.Status.EXPECTATION_FAILED, e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
+        } catch (Exception e) {
+            log.error("Unexpected error during node resume: {}", e.getMessage(), e);
+            throw new ApiException(Response.Status.INTERNAL_SERVER_ERROR, "Failed to resume node: " + e.getMessage());
+        }
+    }
+
     public void terminateWorkflow(WorkflowTerminateRequest workflowTerminateRequest) {
         try {
             GenericWorkflow workflow = client.newWorkflowStub(GenericWorkflow.class, workflowTerminateRequest.getWorkflowId());

--- a/api/src/main/java/com/flipkart/drift/api/service/builder/NodeDefinitionService.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/builder/NodeDefinitionService.java
@@ -1,6 +1,7 @@
 package com.flipkart.drift.api.service.builder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flipkart.drift.api.client.CacheInvalidationClient;
 import com.flipkart.drift.persistence.dao.ConnectionType;
 import com.flipkart.drift.persistence.dao.NodeDefinitionDao;
 import com.flipkart.drift.persistence.entity.NodeHB;
@@ -8,26 +9,22 @@ import com.flipkart.drift.commons.exception.ApiException;
 import com.flipkart.drift.commons.model.enums.Version;
 import com.flipkart.drift.commons.model.node.NodeDefinition;
 import com.google.inject.Inject;
-import redis.clients.jedis.JedisSentinelPool;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 
 import static com.flipkart.drift.commons.utils.Utility.*;
 
-import static com.flipkart.drift.api.service.utils.Utility.publishRedisEvent;
-import static com.flipkart.drift.commons.utils.Constants.Workflow.DSL_UPDATE_CHANNEL;
-
 public class NodeDefinitionService {
     public static final String NODE_EVENT_ID = "NODE";
     private final NodeDefinitionDao nodeDefinitionDao;
-    private final JedisSentinelPool jedisSentinelPool;
+    private final CacheInvalidationClient cacheInvalidationClient;
 
     @Inject
     public NodeDefinitionService(NodeDefinitionDao nodeDefinitionDao, ObjectMapper objectMapper,
-                                 JedisSentinelPool jedisSentinelPool) {
+                                 CacheInvalidationClient cacheInvalidationClient) {
         this.nodeDefinitionDao = nodeDefinitionDao;
-        this.jedisSentinelPool = jedisSentinelPool;
+        this.cacheInvalidationClient = cacheInvalidationClient;
     }
 
     public NodeDefinition addNode(NodeDefinition wfNodeData) {
@@ -81,8 +78,8 @@ public class NodeDefinitionService {
                 String versionKey = generateRowKey(id, version);
                 createNode(versionKey, nodeDefinition); // ABC_1
 
-                publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, NODE_EVENT_ID + " " + versionKey);
-                publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, NODE_EVENT_ID + " " + latestKey);
+                cacheInvalidationClient.invalidate(NODE_EVENT_ID, versionKey);
+                cacheInvalidationClient.invalidate(NODE_EVENT_ID, latestKey);
 
                 return;
             }
@@ -95,8 +92,8 @@ public class NodeDefinitionService {
             createNode(versionKey, nodeDefinition); //ABC_2, ABC_3
 
             updateNodeInHBase(generateRowKey(id, Version.LATEST), nodeDefinition);//Update of latest
-            publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, NODE_EVENT_ID + " " + versionKey);
-            publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, NODE_EVENT_ID + " " + latestKey);
+            cacheInvalidationClient.invalidate(NODE_EVENT_ID, versionKey);
+            cacheInvalidationClient.invalidate(NODE_EVENT_ID, latestKey);
 
 
         } catch (Exception e) {

--- a/api/src/main/java/com/flipkart/drift/api/service/builder/WorkflowDefinitionService.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/builder/WorkflowDefinitionService.java
@@ -2,6 +2,7 @@ package com.flipkart.drift.api.service.builder;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flipkart.drift.api.client.CacheInvalidationClient;
 import com.flipkart.drift.api.service.utils.WorkflowGraphNode;
 import com.flipkart.drift.commons.exception.ApiException;
 import com.flipkart.drift.commons.model.enums.NodeType;
@@ -23,9 +24,7 @@ import guru.nidi.graphviz.engine.GraphvizJdkEngine;
 import guru.nidi.graphviz.model.Graph;
 import guru.nidi.graphviz.model.Node;
 import lombok.extern.slf4j.Slf4j;
-import redis.clients.jedis.JedisSentinelPool;
 
-import static com.flipkart.drift.api.service.utils.Utility.publishRedisEvent;
 import static guru.nidi.graphviz.model.Factory.graph;
 import static guru.nidi.graphviz.model.Factory.node;
 import static guru.nidi.graphviz.model.Link.to;
@@ -36,7 +35,6 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.flipkart.drift.commons.utils.Constants.Workflow.DSL_UPDATE_CHANNEL;
 import static com.flipkart.drift.commons.utils.Utility.*;
 
 @Slf4j
@@ -44,16 +42,16 @@ public class WorkflowDefinitionService {
 
     public static final String WORKFLOW_EVENT_ID = "WORKFLOW";
     private final WorkflowDefinitionDao workflowDefinitionDao;
-    private final JedisSentinelPool jedisSentinelPool;
+    private final CacheInvalidationClient cacheInvalidationClient;
     private final NodeDefinitionService nodeDefinitionService;
 
 
     @Inject
     public WorkflowDefinitionService(WorkflowDefinitionDao workflowDefinitionDao, ObjectMapper objectMapper,
-                                     JedisSentinelPool jedisSentinelPool,
+                                     CacheInvalidationClient cacheInvalidationClient,
                                      NodeDefinitionService nodeDefinitionService) {
         this.workflowDefinitionDao = workflowDefinitionDao;
-        this.jedisSentinelPool = jedisSentinelPool;
+        this.cacheInvalidationClient = cacheInvalidationClient;
         this.nodeDefinitionService = nodeDefinitionService;
     }
 
@@ -240,8 +238,8 @@ public class WorkflowDefinitionService {
 
                 String versionKey = generateRowKey(id, version);
                 createWorkflow(versionKey, workflow); // ABC_1
-                publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, WORKFLOW_EVENT_ID + " " + versionKey);
-                publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, WORKFLOW_EVENT_ID + " " + latestKey);
+                cacheInvalidationClient.invalidate(WORKFLOW_EVENT_ID, versionKey);
+                cacheInvalidationClient.invalidate(WORKFLOW_EVENT_ID, latestKey);
 
                 return;
             }
@@ -254,8 +252,8 @@ public class WorkflowDefinitionService {
             createWorkflow(versionKey, workflow); // ABC_2 abc_3
 
             updateWorkflowInHBase(latestKey, workflow); //ABC_LATEST->Data of ABC_2 abc3
-            publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, WORKFLOW_EVENT_ID + " " + versionKey);
-            publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, WORKFLOW_EVENT_ID + " " + latestKey);
+            cacheInvalidationClient.invalidate(WORKFLOW_EVENT_ID, versionKey);
+            cacheInvalidationClient.invalidate(WORKFLOW_EVENT_ID, latestKey);
 
         } catch (Exception e) {
             throw new ApiException("Error while publishing workflow in HBase", Response.Status.INTERNAL_SERVER_ERROR, e);
@@ -315,7 +313,7 @@ public class WorkflowDefinitionService {
 
         String activeKey = generateRowKey(id, Version.ACTIVE);
         createWorkflow(activeKey, workflow);
-        publishRedisEvent(jedisSentinelPool, DSL_UPDATE_CHANNEL, WORKFLOW_EVENT_ID + " " + activeKey);
+        cacheInvalidationClient.invalidate(WORKFLOW_EVENT_ID, activeKey);
 
     }
 

--- a/api/src/main/resources/config/configuration.yaml
+++ b/api/src/main/resources/config/configuration.yaml
@@ -28,6 +28,7 @@ redisConfiguration:
   minIdle: 25
   testOnBorrow: true
   blockWhenExhausted: true
+  redisEnabled: false  # set to false in environments without Redis; requires ASYNC executionMode
 
 cacheRefreshExecutorServiceConfig:
   minThreads: 1
@@ -51,3 +52,12 @@ temporalTaskQueue: ${TEMPORAL_TASK_QUEUE}
 hadoopUserName: ${HADOOP_USERNAME}
 
 hadoopLoginUser: ${HADOOP_LOGIN_USER}
+
+# DNS-fanout cache invalidation (used when redisEnabled=false).
+# Set headlessServiceHost to the K8s headless service DNS name for worker pods so that
+# InetAddress.getAllByName() resolves to all pod IPs.
+workerInvalidationConfig:
+  headlessServiceHost: ${WORKER_HEADLESS_HOST:}
+  adminPort: 5601
+  perPodTimeoutMs: 2000
+  enabled: true

--- a/commons/src/main/java/com/flipkart/drift/commons/model/temporal/WorkflowState.java
+++ b/commons/src/main/java/com/flipkart/drift/commons/model/temporal/WorkflowState.java
@@ -2,6 +2,7 @@ package com.flipkart.drift.commons.model.temporal;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.flipkart.drift.sdk.model.client.IssueDetail;
+import com.flipkart.drift.sdk.model.enums.WorkflowExecutionMode;
 import com.flipkart.drift.sdk.model.response.View;
 import com.flipkart.drift.sdk.model.enums.WorkflowStatus;
 import lombok.AllArgsConstructor;
@@ -25,4 +26,6 @@ public class WorkflowState implements Serializable {
     private View view;
     private String currentNodeRef;
     private IssueDetail issueDetail;
+    /** Workflow-level execution mode set when the workflow was started; null for legacy workflows (treated as SYNC). */
+    private WorkflowExecutionMode workflowExecutionMode;
 }

--- a/commons/src/main/java/com/flipkart/drift/workflows/GenericWorkflow.java
+++ b/commons/src/main/java/com/flipkart/drift/workflows/GenericWorkflow.java
@@ -19,7 +19,7 @@ public interface GenericWorkflow {
     void resumeWorkflow(WorkflowResumeRequest workflowResumeRequest);
 
     @SignalMethod
-    void resumeNode(String nodeId);
+    void unsidelineWorkflow(String nodeId);
 
     @SignalMethod
     void terminateWorkflow(WorkflowTerminateRequest workflowTerminateRequest);

--- a/commons/src/main/java/com/flipkart/drift/workflows/GenericWorkflow.java
+++ b/commons/src/main/java/com/flipkart/drift/workflows/GenericWorkflow.java
@@ -19,6 +19,9 @@ public interface GenericWorkflow {
     void resumeWorkflow(WorkflowResumeRequest workflowResumeRequest);
 
     @SignalMethod
+    void resumeNode(String nodeId);
+
+    @SignalMethod
     void terminateWorkflow(WorkflowTerminateRequest workflowTerminateRequest);
 
     @QueryMethod

--- a/java-sdk/src/main/java/com/flipkart/drift/sdk/model/enums/WorkflowExecutionMode.java
+++ b/java-sdk/src/main/java/com/flipkart/drift/sdk/model/enums/WorkflowExecutionMode.java
@@ -1,0 +1,12 @@
+package com.flipkart.drift.sdk.model.enums;
+
+/**
+ * Controls how the API call behaves when starting or resuming a workflow.
+ * SYNC  - the API thread blocks until the workflow reaches a terminal state (requires Redis).
+ * ASYNC - the API returns immediately with RUNNING status; the workflow completes in the background.
+ * Defaults to SYNC for backward compatibility.
+ */
+public enum WorkflowExecutionMode {
+    ASYNC,
+    SYNC
+}

--- a/java-sdk/src/main/java/com/flipkart/drift/sdk/model/enums/WorkflowStatus.java
+++ b/java-sdk/src/main/java/com/flipkart/drift/sdk/model/enums/WorkflowStatus.java
@@ -9,6 +9,5 @@ public enum WorkflowStatus {
     TERMINATED,
     DELEGATED,
     SCHEDULER_WAITING,
-    ASYNC_COMPLETE,
-    PAUSED_FOR_RESUME
+    ASYNC_COMPLETE
 }

--- a/java-sdk/src/main/java/com/flipkart/drift/sdk/model/enums/WorkflowStatus.java
+++ b/java-sdk/src/main/java/com/flipkart/drift/sdk/model/enums/WorkflowStatus.java
@@ -9,5 +9,6 @@ public enum WorkflowStatus {
     TERMINATED,
     DELEGATED,
     SCHEDULER_WAITING,
-    ASYNC_COMPLETE
+    ASYNC_COMPLETE,
+    PAUSED_FOR_RESUME
 }

--- a/java-sdk/src/main/java/com/flipkart/drift/sdk/model/request/WorkflowStartRequest.java
+++ b/java-sdk/src/main/java/com/flipkart/drift/sdk/model/request/WorkflowStartRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.flipkart.drift.sdk.model.client.Customer;
 import com.flipkart.drift.sdk.model.client.IssueDetail;
 import com.flipkart.drift.sdk.model.client.OrderDetail;
+import com.flipkart.drift.sdk.model.enums.WorkflowExecutionMode;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -28,4 +29,10 @@ public class WorkflowStartRequest extends WorkflowRequest {
     @Deprecated
     private Set<OrderDetail> orderDetails;
     private Map<String, Object> config;
+    /**
+     * Controls whether the API call blocks waiting for a terminal state (SYNC) or returns immediately (ASYNC).
+     * Defaults to SYNC for backward compatibility.
+     * SYNC requires Redis to be enabled; use ASYNC in Redis-free environments.
+     */
+    private WorkflowExecutionMode workflowExecutionMode = WorkflowExecutionMode.SYNC;
 }

--- a/package/helm-chart/api/values.yaml
+++ b/package/helm-chart/api/values.yaml
@@ -37,6 +37,9 @@ env:
   HADOOP_USERNAME: "your-hadoop-username"
   HADOOP_LOGIN_USER: "your-hadoop-login-user"
   ZOOKEEPER_QUORUM_HOT: "your-zookeeper-quorum"
+  # DNS name of the worker headless service for cache invalidation fanout (used when redisEnabled=false).
+  # Format: <worker-release-name>-headless.<namespace>.svc.cluster.local
+  WORKER_HEADLESS_HOST: "drift-worker-headless.drift.svc.cluster.local"
 
 jvm:
   heapSize:

--- a/package/helm-chart/worker/templates/headless-service.yaml
+++ b/package/helm-chart/worker/templates/headless-service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.headlessService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-headless
+  namespace: {{ .Values.namespace }}
+  labels:
+{{- range $key, $val := .Values.labels }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
+spec:
+  clusterIP: None  # headless: DNS resolves to individual pod IPs
+  selector:
+{{- range $key, $val := .Values.selectorLabels }}
+    {{ $key }}: {{ $val | quote }}
+{{- end }}
+  ports:
+    - name: admin
+      port: {{ .Values.headlessService.adminPort }}
+      targetPort: {{ .Values.headlessService.adminPort }}
+      protocol: TCP
+{{- end }}

--- a/package/helm-chart/worker/values.yaml
+++ b/package/helm-chart/worker/values.yaml
@@ -55,6 +55,13 @@ jvm:
     xms: "1g"
     xmx: "1g"
 
+# Headless K8s service so the API can resolve all worker pod IPs for DNS-fanout
+# cache invalidation when Redis is unavailable.
+# DNS name from API pods: <release-name>-headless.<namespace>.svc.cluster.local
+headlessService:
+  enabled: true
+  adminPort: 5601
+
 # Config files - each config is in its own section for easy management
 # These are clean, human-readable configuration files
 configFiles:

--- a/worker/src/main/java/com/flipkart/drift/worker/activities/BaseNodeActivityImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/activities/BaseNodeActivityImpl.java
@@ -15,6 +15,7 @@ import com.flipkart.drift.worker.model.activity.ActivityRequest;
 import com.flipkart.drift.worker.model.activity.ActivityResponse;
 import com.flipkart.drift.worker.service.WorkflowContextHBService;
 import com.flipkart.drift.commons.utils.ObjectMapperUtil;
+import com.flipkart.drift.sdk.model.enums.WorkflowStatus;
 import io.temporal.activity.Activity;
 import lombok.extern.slf4j.Slf4j;
 
@@ -81,6 +82,17 @@ public abstract class BaseNodeActivityImpl<T extends NodeDefinition> implements 
         activityRequest.setNodeDefinition(activityThinRequest.getNodeDefinition());
         // Step 2: Execute the actual logic
         ActivityResponse response = executeNode(activityRequest);
+
+        // Step 2b: If node is marked as terminal (end=true) and the node's own status is still
+        // transitional (RUNNING or WAITING), override to COMPLETED so all node types correctly
+        // terminate the workflow. FAILED, COMPLETED, and ASYNC_COMPLETE are intentional and preserved.
+        if (Boolean.TRUE.equals(activityRequest.getIsTerminal())
+                && response.getWorkflowStatus() != WorkflowStatus.FAILED
+                && response.getWorkflowStatus() != WorkflowStatus.COMPLETED
+                && response.getWorkflowStatus() != WorkflowStatus.ASYNC_COMPLETE) {
+            response.setWorkflowStatus(WorkflowStatus.COMPLETED);
+        }
+
         // Step 3: Persist updated context
         workflowContextHBService.updateEntity(WorkflowContext.builder()
                 .workflowId(workflowId)

--- a/worker/src/main/java/com/flipkart/drift/worker/activities/InstructionNodeActivityImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/activities/InstructionNodeActivityImpl.java
@@ -64,7 +64,8 @@ public class InstructionNodeActivityImpl extends BaseNodeActivityImpl<Instructio
             if (workflowAttributeDetails != null) {
                 workflowStatus = WorkflowStatus.valueOf(workflowAttributeDetails.getAttribute());
             } else {
-                workflowStatus = activityRequest.getIsTerminal() ? WorkflowStatus.COMPLETED : WorkflowStatus.WAITING;
+                // Always return WAITING here; BaseNodeActivityImpl overrides to COMPLETED when isTerminal=true
+                workflowStatus = WorkflowStatus.WAITING;
             }
 
             return ActivityResponse.builder()

--- a/worker/src/main/java/com/flipkart/drift/worker/activities/ReturnControlActivityImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/activities/ReturnControlActivityImpl.java
@@ -1,6 +1,5 @@
 package com.flipkart.drift.worker.activities;
 
-import com.flipkart.drift.worker.config.RedisConfiguration;
 import com.google.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import redis.clients.jedis.Jedis;
@@ -10,17 +9,12 @@ import static com.flipkart.drift.commons.utils.Constants.Workflow.ASYNC_AWAIT_CH
 
 @Slf4j
 public class ReturnControlActivityImpl implements ReturnControlActivity {
-    private final RedisConfiguration redisConfiguration;
-    private final JedisPoolAbstract jedisSentinelPool;
+
+    @Inject(optional = true)
+    private JedisPoolAbstract jedisSentinelPool;
 
     @Inject
-    public ReturnControlActivityImpl(RedisConfiguration redisConfiguration, JedisPoolAbstract jedisSentinelPool) {
-        this.redisConfiguration = redisConfiguration;
-        this.jedisSentinelPool = jedisSentinelPool;
-    }
-
-    public String getRedisKey(String key) {
-        return redisConfiguration.getPrefix() + ":" + key;
+    public ReturnControlActivityImpl() {
     }
 
     public Long exec(String workflowId) {

--- a/worker/src/main/java/com/flipkart/drift/worker/bootstrap/DslCacheManager.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/bootstrap/DslCacheManager.java
@@ -1,0 +1,59 @@
+package com.flipkart.drift.worker.bootstrap;
+
+import com.flipkart.drift.persistence.cache.EntityVersionedCache;
+import com.flipkart.drift.persistence.cache.NodeDefinitionCache;
+import com.flipkart.drift.persistence.cache.WorkflowCache;
+import com.google.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Shared DSL cache invalidation logic used by both {@link RedisCacheInvalidator}
+ * (Redis pub-sub path) and {@link com.flipkart.drift.worker.task.CacheInvalidationTask}
+ * (DNS-fanout HTTP path).
+ */
+@Slf4j
+public class DslCacheManager {
+
+    public static final String NODE_EVENT_ID = "NODE";
+    public static final String WORKFLOW_EVENT_ID = "WORKFLOW";
+    public static final String ALL = "ALL";
+
+    private final NodeDefinitionCache nodeDefinitionCache;
+    private final WorkflowCache workflowCache;
+
+    @Inject
+    public DslCacheManager(NodeDefinitionCache nodeDefinitionCache, WorkflowCache workflowCache) {
+        this.nodeDefinitionCache = nodeDefinitionCache;
+        this.workflowCache = workflowCache;
+    }
+
+    /**
+     * Invalidates a single cache entry or the entire cache for the given type.
+     *
+     * @param type  "NODE" or "WORKFLOW"
+     * @param key   HBase row key to invalidate, or "ALL" to invalidate the entire cache
+     * @return true if the cache was found and invalidated, false if type is unknown
+     */
+    public boolean invalidate(String type, String key) {
+        EntityVersionedCache<?> cache = getCache(type);
+        if (cache == null) {
+            log.warn("Unknown cache type: {}, ignoring invalidation for key {}", type, key);
+            return false;
+        }
+        log.info("Invalidating cache: type={}, key={}", type, key);
+        if (ALL.equalsIgnoreCase(key)) {
+            cache.invalidateAll();
+        } else {
+            cache.invalidate(key);
+        }
+        return true;
+    }
+
+    private EntityVersionedCache<?> getCache(String type) {
+        switch (type) {
+            case NODE_EVENT_ID: return nodeDefinitionCache;
+            case WORKFLOW_EVENT_ID: return workflowCache;
+            default: return null;
+        }
+    }
+}

--- a/worker/src/main/java/com/flipkart/drift/worker/bootstrap/RedisCacheInvalidator.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/bootstrap/RedisCacheInvalidator.java
@@ -1,8 +1,6 @@
 package com.flipkart.drift.worker.bootstrap;
 
-import com.flipkart.drift.persistence.cache.EntityVersionedCache;
-import com.flipkart.drift.persistence.cache.NodeDefinitionCache;
-import com.flipkart.drift.persistence.cache.WorkflowCache;
+import com.flipkart.drift.worker.config.DriftWorkerConfiguration;
 import io.dropwizard.lifecycle.Managed;
 import lombok.extern.slf4j.Slf4j;
 import redis.clients.jedis.Jedis;
@@ -19,22 +17,20 @@ import static com.flipkart.drift.commons.utils.Constants.Workflow.DSL_UPDATE_CHA
 
 @Slf4j
 public class RedisCacheInvalidator implements Managed {
-    public static final String NODE_EVENT_ID = "NODE";
-    public static final String WORKFLOW_EVENT_ID = "WORKFLOW";
 
-    private final NodeDefinitionCache nodeDefinitionCache;
-    private final WorkflowCache workflowCache;
-    private final JedisPoolAbstract jedisPool;
+    private final DslCacheManager dslCacheManager;
+    private final boolean redisEnabled;
     private final ExecutorService executorService;
-    private volatile boolean running = false;  
-    
+    private volatile boolean running = false;
+
+    @Inject(optional = true)
+    private JedisPoolAbstract jedisPool;
+
     @Inject
-    public RedisCacheInvalidator(NodeDefinitionCache nodeDefinitionCache,
-                                 WorkflowCache workflowCache,
-                                 JedisPoolAbstract jedisPool) {
-        this.nodeDefinitionCache = nodeDefinitionCache;
-        this.workflowCache = workflowCache;
-        this.jedisPool = jedisPool;
+    public RedisCacheInvalidator(DslCacheManager dslCacheManager,
+                                 DriftWorkerConfiguration driftWorkerConfiguration) {
+        this.dslCacheManager = dslCacheManager;
+        this.redisEnabled = driftWorkerConfiguration.getRedisConfiguration().isRedisEnabled();
         this.executorService = Executors.newSingleThreadExecutor(
                 new ThreadFactoryBuilder()
                         .setNameFormat("redis-subscriber-%d")
@@ -45,6 +41,14 @@ public class RedisCacheInvalidator implements Managed {
 
     @Override
     public void start() throws Exception {
+        if (!redisEnabled) {
+            log.info("Redis is disabled (redisEnabled=false), skipping cache invalidation subscription");
+            return;
+        }
+        if (jedisPool == null) {
+            log.warn("Redis pool is null despite redisEnabled=true, skipping cache invalidation subscription");
+            return;
+        }
         try {
             log.info("Starting Redis cache invalidation listener");
             running = true;
@@ -57,20 +61,13 @@ public class RedisCacheInvalidator implements Managed {
                             public void onMessage(String channel, String message) {
                                 try {
                                     log.info("Received cache invalidation message: {}", message);
-                                /*
-                                    message is of format : NODE <rowKey> or NODE ALL or WORKFLOW <rowKey> or WORKFLOW ALL
-                                */
+                                    // message format: NODE <rowKey> | NODE ALL | WORKFLOW <rowKey> | WORKFLOW ALL
                                     String[] parts = message.split(" ", 2);
-                                    EntityVersionedCache<?> cache = getCache(parts[0]);
-                                    if (cache != null) {
-                                        if (parts[1].equals("ALL")) {
-                                            cache.invalidateAll();
-                                        } else {
-                                            cache.invalidate(parts[1]);
-                                        }
-                                    } else {
-                                        log.warn("Unknown cache type: {}, ignoring msg {}", parts[0], message);
+                                    if (parts.length < 2) {
+                                        log.warn("Malformed cache invalidation message: {}", message);
+                                        return;
                                     }
+                                    dslCacheManager.invalidate(parts[0], parts[1]);
                                 } catch (Exception e) {
                                     log.error("Error processing cache invalidation message", e);
                                 }
@@ -102,18 +99,6 @@ public class RedisCacheInvalidator implements Managed {
             });
         } catch (Exception e) {
             log.error("Failure starting Redis cache invalidation listener", e);
-        }
-    }
-
-    private EntityVersionedCache<?> getCache(String dslId) {
-        switch (dslId) {
-            case NODE_EVENT_ID:
-                return nodeDefinitionCache;
-            case WORKFLOW_EVENT_ID:
-                return workflowCache;
-            default:
-                log.warn("Unknown cache type: {}", dslId);
-                return null;
         }
     }
 

--- a/worker/src/main/java/com/flipkart/drift/worker/bootstrap/WorkerApplication.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/bootstrap/WorkerApplication.java
@@ -1,6 +1,7 @@
 package com.flipkart.drift.worker.bootstrap;
 
 import com.flipkart.drift.persistence.bootstrap.DriftEntityModule;
+import com.flipkart.drift.worker.task.CacheInvalidationTask;
 import com.flipkart.drift.worker.util.AuthNTokenGenerator;
 import com.flipkart.drift.worker.config.DriftWorkerConfiguration;
 import com.flipkart.drift.worker.resources.DriftWorkerResource;
@@ -93,6 +94,7 @@ public class WorkerApplication extends Application<DriftWorkerConfiguration> {
         environment.lifecycle().manage(new TemporalWorkerManaged(injector, driftWorkerConfiguration, metricsScope));
         environment.lifecycle().manage(injector.getInstance(RedisCacheInvalidator.class));
         environment.jersey().register(injector.getInstance(DriftWorkerResource.class));
+        environment.admin().addTask(injector.getInstance(CacheInvalidationTask.class));
     }
 
     private static ConcurrentCompositeConfiguration getConcurrentCompositeConfiguration(DriftWorkerConfiguration configuration) {

--- a/worker/src/main/java/com/flipkart/drift/worker/bootstrap/WorkerModule.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/bootstrap/WorkerModule.java
@@ -51,8 +51,12 @@ public class WorkerModule extends AbstractModule {
     }
 
     private JedisSentinelPool provideJedisPool() {
+        final RedisConfiguration redisConfiguration = driftWorkerConfiguration.getRedisConfiguration();
+        if (!redisConfiguration.isRedisEnabled()) {
+            log.info("Redis is disabled (redisEnabled=false), skipping JedisSentinelPool creation");
+            return null;
+        }
         try {
-            final RedisConfiguration redisConfiguration = driftWorkerConfiguration.getRedisConfiguration();
             String hosts = redisConfiguration.getSentinels();
             StringTokenizer strTkn = new StringTokenizer(hosts, ",");
             List<String> hostList = new ArrayList<>();
@@ -165,7 +169,11 @@ public class WorkerModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        bind(JedisPoolAbstract.class).toInstance(this.jedisSentinelPool);
+        if (this.jedisSentinelPool != null) {
+            bind(JedisPoolAbstract.class).toInstance(this.jedisSentinelPool);
+        }
+        // When jedisSentinelPool is null (Redis disabled), JedisPoolAbstract is unbound.
+        // Classes using @Inject(optional=true) field injection will receive null gracefully.
         bind(DriftWorkerConfiguration.class).toInstance(driftWorkerConfiguration);
         bind(StringResolver.class).to(MustacheStringResolver.class);
         bind(Connection.class).annotatedWith(Names.named(ConnectionType.HOT.name())).toProvider(ConnectionProviderWorker.class).asEagerSingleton();

--- a/worker/src/main/java/com/flipkart/drift/worker/config/RedisConfiguration.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/config/RedisConfiguration.java
@@ -18,4 +18,5 @@ public class RedisConfiguration {
     private int maxWaitMillis;
     private boolean testOnBorrow;
     private boolean blockWhenExhausted;
+    private boolean redisEnabled = true;
 }

--- a/worker/src/main/java/com/flipkart/drift/worker/model/activity/ActivityResponse.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/model/activity/ActivityResponse.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.io.Serializable;
 
@@ -13,6 +14,7 @@ import java.io.Serializable;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Setter
 public class ActivityResponse implements Serializable {
     private WorkflowStatus workflowStatus;
     private JsonNode nodeResponse;

--- a/worker/src/main/java/com/flipkart/drift/worker/task/CacheInvalidationTask.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/task/CacheInvalidationTask.java
@@ -1,0 +1,56 @@
+package com.flipkart.drift.worker.task;
+
+import com.flipkart.drift.worker.bootstrap.DslCacheManager;
+import com.google.inject.Inject;
+import io.dropwizard.servlets.tasks.Task;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Dropwizard admin task for DNS-fanout based cache invalidation.
+ * Registered on the admin port so the API can POST to each worker pod directly
+ * when Redis pub-sub is unavailable.
+ *
+ * Usage:
+ *   POST /tasks/cache-invalidate?type=NODE&key=<rowKey>
+ *   POST /tasks/cache-invalidate?type=WORKFLOW&key=<rowKey>
+ *   POST /tasks/cache-invalidate?type=NODE&key=ALL   (invalidates entire cache)
+ */
+@Slf4j
+public class CacheInvalidationTask extends Task {
+
+    private final DslCacheManager dslCacheManager;
+
+    @Inject
+    public CacheInvalidationTask(DslCacheManager dslCacheManager) {
+        super("cache-invalidate");
+        this.dslCacheManager = dslCacheManager;
+    }
+
+    @Override
+    public void execute(Map<String, List<String>> parameters, PrintWriter output) throws Exception {
+        String type = getFirst(parameters, "type");
+        String key = getFirst(parameters, "key");
+
+        if (type == null || key == null) {
+            output.println("ERROR: required params: type (NODE|WORKFLOW), key (<rowKey> or ALL)");
+            return;
+        }
+
+        log.info("Cache invalidation task invoked: type={}, key={}", type, key);
+        boolean found = dslCacheManager.invalidate(type, key);
+        if (found) {
+            output.println("OK: invalidated type=" + type + " key=" + key);
+        } else {
+            output.println("ERROR: unknown cache type: " + type + " (expected NODE or WORKFLOW)");
+        }
+    }
+
+    private String getFirst(Map<String, List<String>> params, String name) {
+        List<String> values = params.get(name);
+        return (values == null || values.isEmpty()) ? null : values.get(0);
+    }
+}

--- a/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
@@ -94,7 +94,7 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
     }
 
     @Override
-    public void resumeNode(String nodeId) {
+    public void unsidelineWorkflow(String nodeId) {
         pausedNodes.put(nodeId, true);
     }
 

--- a/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
@@ -138,6 +138,11 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
                 if (af.getCause() instanceof CanceledFailure) {
                     throw af;
                 }
+                if (workflowState.getStatus() == WorkflowStatus.TERMINATED) {
+                    throw ApplicationFailure.newNonRetryableFailure(
+                            "Workflow terminated while executing node: " + nodeId, "WORKFLOW_TERMINATED"
+                    );
+                }
                 logger.warn("WfId: {} Node: {} failed — pausing for resume signal", workflowState.getWorkflowId(), nodeId);
                 workflowState.setStatus(WorkflowStatus.PAUSED_FOR_RESUME);
                 workflowState.setCurrentNodeRef(nodeId);

--- a/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
@@ -115,13 +115,12 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
             ActivityThinResponse activityThinResponse;
             try {
                 logger.info("WfId : {} Running node: {}", workflowId, currentNode.getInstanceName());
-                activityThinResponse = executeNodeWithPause(currentNode, threadContext, workflowStartRequest);
+                activityThinResponse = executeNodeWithPause(currentNode, threadContext, workflowStartRequest, workflow);
             } catch (Exception e) {
                 if (workflowState.getStatus() == WorkflowStatus.TERMINATED) {
                     return;
                 }
-                currentNode = nodeExecutor.handleNodeExecutionError(e, workflow);
-                continue;
+                throw e;
             }
             if (activityThinResponse != null) {
                 nodeExecutor.handleNodeResponseStatus(workflowId, activityThinResponse, workflow, threadContext);
@@ -130,7 +129,8 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
         }
     }
 
-    private ActivityThinResponse executeNodeWithPause(WorkflowNode currentNode, Map<String, String> threadContext, WorkflowStartRequest workflowStartRequest) {
+    private ActivityThinResponse executeNodeWithPause(WorkflowNode currentNode, Map<String, String> threadContext,
+                                                       WorkflowStartRequest workflowStartRequest, Workflow workflow) {
         String nodeId = currentNode.getInstanceName();
         while (true) {
             try {
@@ -144,10 +144,13 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
                             "Workflow terminated while executing node: " + nodeId, "WORKFLOW_TERMINATED"
                     );
                 }
-                logger.warn("WfId: {} Node: {} failed — pausing for resume signal", workflowState.getWorkflowId(), nodeId);
+
+                runFallbackNode(workflow, threadContext, nodeId);
+
+                logger.info("WfId: {} Node: {} failed — pausing for unsideline signal", workflowState.getWorkflowId(), nodeId);
                 workflowState.setStatus(WorkflowStatus.FAILED);
                 workflowState.setCurrentNodeRef(nodeId);
-                workflowState.setErrorMessage(af.getMessage());
+                workflowState.setErrorMessage("Error message: " + af.getMessage());
 
                 pausedNodes.putIfAbsent(nodeId, false);
                 io.temporal.workflow.Workflow.await(
@@ -163,10 +166,27 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
 
                 pausedNodes.remove(nodeId);
                 workflowState.setErrorMessage(null);
-                logger.info("WfId: {} Node: {} received resume signal — retrying", workflowState.getWorkflowId(), nodeId);
+                logger.info("WfId: {} Node: {} received unsideline signal — retrying", workflowState.getWorkflowId(), nodeId);
                 workflowState.setStatus(WorkflowStatus.RUNNING);
-                // loop back → retry node with fresh execution
+                // loop back → retry currentNode with fresh execution
             }
+        }
+    }
+
+    private void runFallbackNode(Workflow workflow, Map<String, String> threadContext, String failedNodeId) {
+        WorkflowNode fallbackNode = workflow.getStates().get(workflow.getDefaultFailureNode());
+        if (fallbackNode == null) {
+            logger.warn("WfId: {} No defaultFailureNode configured — skipping fallback for failed node: {}",
+                    workflowState.getWorkflowId(), failedNodeId);
+            return;
+        }
+        try {
+            logger.info("WfId: {} Running fallback node: {} for failed node: {}",
+                    workflowState.getWorkflowId(), fallbackNode.getInstanceName(), failedNodeId);
+            nodeExecutor.executeNodeWithoutStatusUpdate(fallbackNode, threadContext);
+        } catch (Exception e) {
+            logger.error("WfId: {} Fallback node: {} failed for node: {} — {}",
+                    workflowState.getWorkflowId(), fallbackNode.getInstanceName(), failedNodeId, e.getMessage(), e);
         }
     }
 

--- a/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
@@ -14,11 +14,14 @@ import com.flipkart.drift.commons.model.node.Workflow;
 import com.flipkart.drift.commons.model.node.WorkflowNode;
 import com.flipkart.drift.commons.model.temporal.WorkflowState;
 import com.flipkart.drift.worker.temporal.OptionsStore;
+import io.temporal.failure.ActivityFailure;
 import io.temporal.failure.ApplicationFailure;
+import io.temporal.failure.CanceledFailure;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @Data
@@ -28,6 +31,7 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
     private final Logger logger = io.temporal.workflow.Workflow.getLogger(GenericWorkflowImpl.class);
     private final WorkflowNodeExecutor nodeExecutor;
     private WorkflowState workflowState;
+    private final Map<String, Boolean> pausedNodes = new HashMap<>();
 
     public GenericWorkflowImpl() {
         this.workflowState = new WorkflowState();
@@ -90,6 +94,11 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
     }
 
     @Override
+    public void resumeNode(String nodeId) {
+        pausedNodes.put(nodeId, true);
+    }
+
+    @Override
     public void terminateWorkflow(WorkflowTerminateRequest workflowTerminateRequest) {
         this.workflowState.setStatus(WorkflowStatus.TERMINATED);
     }
@@ -105,8 +114,11 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
             ActivityThinResponse activityThinResponse;
             try {
                 logger.info("WfId : {} Running node: {}", workflowId, currentNode.getInstanceName());
-                activityThinResponse = nodeExecutor.executeNode(currentNode, threadContext, workflowStartRequest);
+                activityThinResponse = executeNodeWithPause(currentNode, threadContext, workflowStartRequest);
             } catch (Exception e) {
+                if (workflowState.getStatus() == WorkflowStatus.TERMINATED) {
+                    return;
+                }
                 currentNode = nodeExecutor.handleNodeExecutionError(e, workflow);
                 continue;
             }
@@ -114,6 +126,41 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
                 nodeExecutor.handleNodeResponseStatus(workflowId, activityThinResponse, workflow, threadContext);
             }
             currentNode = workflow.getStates().get(currentNode.getNextNode());
+        }
+    }
+
+    private ActivityThinResponse executeNodeWithPause(WorkflowNode currentNode, Map<String, String> threadContext, WorkflowStartRequest workflowStartRequest) {
+        String nodeId = currentNode.getInstanceName();
+        while (true) {
+            try {
+                return nodeExecutor.executeNode(currentNode, threadContext, workflowStartRequest);
+            } catch (ActivityFailure af) {
+                if (af.getCause() instanceof CanceledFailure) {
+                    throw af;
+                }
+                logger.warn("WfId: {} Node: {} failed — pausing for resume signal", workflowState.getWorkflowId(), nodeId);
+                workflowState.setStatus(WorkflowStatus.PAUSED_FOR_RESUME);
+                workflowState.setCurrentNodeRef(nodeId);
+                workflowState.setErrorMessage(af.getMessage());
+
+                pausedNodes.putIfAbsent(nodeId, false);
+                io.temporal.workflow.Workflow.await(
+                        () -> Boolean.TRUE.equals(pausedNodes.get(nodeId))
+                                || workflowState.getStatus() == WorkflowStatus.TERMINATED
+                );
+
+                if (workflowState.getStatus() == WorkflowStatus.TERMINATED) {
+                    throw ApplicationFailure.newNonRetryableFailure(
+                            "Workflow terminated while paused at node: " + nodeId, "WORKFLOW_TERMINATED"
+                    );
+                }
+
+                pausedNodes.remove(nodeId);
+                workflowState.setErrorMessage(null);
+                logger.info("WfId: {} Node: {} received resume signal — retrying", workflowState.getWorkflowId(), nodeId);
+                workflowState.setStatus(WorkflowStatus.RUNNING);
+                // loop back → retry node with fresh execution
+            }
         }
     }
 

--- a/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.annotation.Timed;
 import com.flipkart.drift.worker.activities.FetchWorkflowActivity;
 import com.flipkart.drift.worker.activities.WorkflowContextManagerActivity;
 import com.flipkart.drift.worker.model.activity.ActivityThinResponse;
+import com.flipkart.drift.sdk.model.enums.WorkflowExecutionMode;
 import com.flipkart.drift.sdk.model.request.WorkflowResumeRequest;
 import com.flipkart.drift.sdk.model.request.WorkflowStartRequest;
 import com.flipkart.drift.sdk.model.request.WorkflowTerminateRequest;
@@ -122,6 +123,11 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
         this.workflowState.setWorkflowId(io.temporal.workflow.Workflow.getInfo().getWorkflowId());
         this.workflowState.setStatus(WorkflowStatus.CREATED);
         this.workflowState.setIssueDetail(workflowStartRequest.getIssueDetail());
+        this.workflowState.setWorkflowExecutionMode(
+                workflowStartRequest.getWorkflowExecutionMode() != null
+                        ? workflowStartRequest.getWorkflowExecutionMode()
+                        : WorkflowExecutionMode.SYNC
+        );
         io.temporal.workflow.Workflow.newActivityStub(WorkflowContextManagerActivity.class, OptionsStore.activityOptions)
                 .persistWorkflowState(workflowStartRequest, io.temporal.workflow.Workflow.getInfo().getWorkflowId());
     }

--- a/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
@@ -144,7 +144,7 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
                     );
                 }
                 logger.warn("WfId: {} Node: {} failed — pausing for resume signal", workflowState.getWorkflowId(), nodeId);
-                workflowState.setStatus(WorkflowStatus.PAUSED_FOR_RESUME);
+                workflowState.setStatus(WorkflowStatus.FAILED);
                 workflowState.setCurrentNodeRef(nodeId);
                 workflowState.setErrorMessage(af.getMessage());
 

--- a/worker/src/main/java/com/flipkart/drift/worker/workflows/WorkflowNodeExecutor.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/workflows/WorkflowNodeExecutor.java
@@ -1,6 +1,7 @@
 package com.flipkart.drift.worker.workflows;
 
 import com.flipkart.drift.commons.model.enums.ExecutionMode;
+import com.flipkart.drift.sdk.model.enums.WorkflowExecutionMode;
 import com.flipkart.drift.commons.model.node.ChildNode;
 import com.flipkart.drift.sdk.model.request.WorkflowStartRequest;
 import com.flipkart.drift.worker.activities.ReturnControlActivity;
@@ -184,7 +185,10 @@ public class WorkflowNodeExecutor {
 
     private void handleWaitingState(String workflowId, ActivityThinResponse activityThinResponse) {
         this.workflowState.setView(activityThinResponse.getView());
-        io.temporal.workflow.Workflow.newActivityStub(ReturnControlActivity.class, OptionsStore.activityOptions).exec(workflowId);
+        // Notify API via Redis only in SYNC mode; ASYNC workflows don't block the API thread
+        if (workflowState.getWorkflowExecutionMode() != WorkflowExecutionMode.ASYNC) {
+            io.temporal.workflow.Workflow.newActivityStub(ReturnControlActivity.class, OptionsStore.activityOptions).exec(workflowId);
+        }
         io.temporal.workflow.Workflow.await(() -> {
             WorkflowStatus status = this.workflowState.getStatus();
             return !(status.equals(WorkflowStatus.WAITING) || status.equals(WorkflowStatus.TERMINATED));
@@ -211,7 +215,9 @@ public class WorkflowNodeExecutor {
         if (activityThinResponse.getErrorResponse() != null) {
             this.workflowState.setErrorMessage(activityThinResponse.getErrorResponse().asText());
         }
-        io.temporal.workflow.Workflow.newActivityStub(ReturnControlActivity.class, OptionsStore.activityOptions).exec(workflowId);
+        if (workflowState.getWorkflowExecutionMode() != WorkflowExecutionMode.ASYNC) {
+            io.temporal.workflow.Workflow.newActivityStub(ReturnControlActivity.class, OptionsStore.activityOptions).exec(workflowId);
+        }
         throw ApplicationFailure.newNonRetryableFailure(
                 "Encountered a failure node",
                 "FAILURE_NODE"
@@ -221,7 +227,9 @@ public class WorkflowNodeExecutor {
     private void handleCompletedState(String workflowId, ActivityThinResponse activityThinResponse, Workflow workflow, Map<String, String> threadContext) {
         this.workflowState.setView(activityThinResponse.getView());
         this.workflowState.setDisposition(activityThinResponse.getDisposition());
-        io.temporal.workflow.Workflow.newActivityStub(ReturnControlActivity.class, OptionsStore.activityOptions).exec(workflowId);
+        if (workflowState.getWorkflowExecutionMode() != WorkflowExecutionMode.ASYNC) {
+            io.temporal.workflow.Workflow.newActivityStub(ReturnControlActivity.class, OptionsStore.activityOptions).exec(workflowId);
+        }
 
         // Execute post-workflow completion nodes if they exist
         if (workflow != null && workflow.getPostWorkflowCompletionNodes() != null && !workflow.getPostWorkflowCompletionNodes().isEmpty()) {
@@ -248,8 +256,10 @@ public class WorkflowNodeExecutor {
     }
 
     private void handleDelegatedState(String workflowId, ActivityThinResponse activityThinResponse) {
-        io.temporal.workflow.Workflow.newActivityStub(ReturnControlActivity.class, OptionsStore.activityOptions)
-                .exec(workflowId);
+        if (workflowState.getWorkflowExecutionMode() != WorkflowExecutionMode.ASYNC) {
+            io.temporal.workflow.Workflow.newActivityStub(ReturnControlActivity.class, OptionsStore.activityOptions)
+                    .exec(workflowId);
+        }
     }
 
     private void updateWorkflowState(ActivityThinResponse response, WorkflowNode currentNode) {

--- a/worker/src/main/resources/config/configuration.yaml
+++ b/worker/src/main/resources/config/configuration.yaml
@@ -18,6 +18,7 @@ redisConfiguration:
   minIdle: 25
   testOnBorrow: true
   blockWhenExhausted: true
+  redisEnabled: false  # set to false in environments without Redis; requires ASYNC executionMode
 
 cacheRefreshExecutorServiceConfig:
   minThreads: 1


### PR DESCRIPTION
When a remote activity fails, the workflow now parks at the failed node and waits for an external resumeNode signal before retrying, instead of routing immediately to the defaultFailureNode. This allows operators to investigate and fix the underlying issue before retrying.

- New PUT /workflow/{workflowId}/node/{nodeId}/resume endpoint sends a resumeNode signal to unblock the waiting workflow
- New PAUSED_FOR_RESUME status exposed via getWorkflowState() so callers know which node to resume
- terminateWorkflow signal correctly unblocks a paused workflow and exits cleanly without routing through the failure node
- putIfAbsent guards against pre-arrived signals being overwritten
- Map entry cleared after resume so repeated failures pause correctly
- Error message cleared on successful retry to avoid stale state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added node-level pause/resume support via a new workflow endpoint to resume a specific node.
  * Introduced configurable workflow execution mode (SYNC/ASYNC) for start and resume APIs.
  * Enabled cache invalidation without Redis by adding DNS-fanout worker cache invalidation (plus a worker admin task to trigger it).
* **Bug Fixes**
  * Improved resilience of node resume/execute behavior with clearer status handling and safer termination semantics.
* **Chores**
  * Updated Helm charts and configuration to support Redis-disabled deployments and worker headless DNS invalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->