### PR TITLE
Added support for Hbase Namespace override

### DIFF
--- a/api/src/main/java/com/flipkart/drift/api/bootstrap/DriftApplication.java
+++ b/api/src/main/java/com/flipkart/drift/api/bootstrap/DriftApplication.java
@@ -14,7 +14,6 @@ import com.flipkart.drift.api.resources.WorkflowResource;
 import com.flipkart.drift.api.resources.NodeDefinitionResource;
 import com.flipkart.drift.api.resources.WorkflowDefinitionResource;
 import com.flipkart.drift.api.module.WorkflowClientModule;
-import com.flipkart.drift.commons.utils.MetricsRegistry;
 import com.flipkart.drift.persistence.dao.ConnectionType;
 import com.google.inject.Guice;
 import com.google.inject.Injector;

--- a/api/src/main/java/com/flipkart/drift/api/bootstrap/DriftApplication.java
+++ b/api/src/main/java/com/flipkart/drift/api/bootstrap/DriftApplication.java
@@ -14,6 +14,8 @@ import com.flipkart.drift.api.resources.WorkflowResource;
 import com.flipkart.drift.api.resources.NodeDefinitionResource;
 import com.flipkart.drift.api.resources.WorkflowDefinitionResource;
 import com.flipkart.drift.api.module.WorkflowClientModule;
+import com.flipkart.drift.commons.utils.MetricsRegistry;
+import com.flipkart.drift.persistence.dao.ConnectionType;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.netflix.config.*;
@@ -57,6 +59,7 @@ public class DriftApplication extends Application<DriftConfiguration> {
 
     @Override
     public void run(DriftConfiguration configuration, Environment environment) {
+        ConnectionType.init(configuration.getHbaseNamespaceConfig());
         // Initialize DynamicPropertyFactory with configuration source
         ConcurrentCompositeConfiguration compositeConfiguration = getConcurrentCompositeConfiguration(configuration);
         DynamicPropertyFactory.initWithConfigurationSource(compositeConfiguration);

--- a/api/src/main/java/com/flipkart/drift/api/config/DriftConfiguration.java
+++ b/api/src/main/java/com/flipkart/drift/api/config/DriftConfiguration.java
@@ -2,6 +2,7 @@ package com.flipkart.drift.api.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.flipkart.drift.persistence.bootstrap.CacheMaxEntriesConfig;
+import com.flipkart.drift.persistence.bootstrap.HbaseNamespaceConfig;
 import com.flipkart.drift.persistence.bootstrap.StaticCacheRefreshConfig;
 import io.dropwizard.Configuration;
 import lombok.Getter;
@@ -21,6 +22,8 @@ public class DriftConfiguration extends Configuration {
     private StaticCacheRefreshConfig staticCacheRefreshConfig;
     @NotNull
     private CacheMaxEntriesConfig cacheMaxEntriesConfig;
+    @NotNull
+    private HbaseNamespaceConfig hbaseNamespaceConfig;
     @NotNull
     private String hbasePropertiesPath;
     @NotNull

--- a/api/src/main/java/com/flipkart/drift/api/config/DriftConfiguration.java
+++ b/api/src/main/java/com/flipkart/drift/api/config/DriftConfiguration.java
@@ -22,7 +22,7 @@ public class DriftConfiguration extends Configuration {
     private StaticCacheRefreshConfig staticCacheRefreshConfig;
     @NotNull
     private CacheMaxEntriesConfig cacheMaxEntriesConfig;
-    @NotNull
+    
     private HbaseNamespaceConfig hbaseNamespaceConfig;
     @NotNull
     private String hbasePropertiesPath;

--- a/api/src/main/resources/config/configuration.yaml
+++ b/api/src/main/resources/config/configuration.yaml
@@ -42,6 +42,12 @@ cacheMaxEntriesConfig:
   nodeDefinitionConfig: 1000 # 100 nodes, 10 versions each
   workflowConfig: 1000 # 100 workflows, 10 versions each
 
+hbaseNamespaceConfig:
+  hot: ${HBASE_NAMESPACE_HOT:-ims_hot}
+  cold: ${HBASE_NAMESPACE_COLD:-ims_cold}
+  archival: ${HBASE_NAMESPACE_ARCHIVAL:-ims_archive}
+  audit: ${HBASE_NAMESPACE_AUDIT:-ims_audit}
+  
 hbasePropertiesPath: ${HBASE_CONFIG_BUCKET}
 
 temporalFrontEnd: ${TEMPORAL_FRONTEND}

--- a/commons/src/main/java/com/flipkart/drift/persistence/bootstrap/HbaseNamespaceConfig.java
+++ b/commons/src/main/java/com/flipkart/drift/persistence/bootstrap/HbaseNamespaceConfig.java
@@ -1,0 +1,13 @@
+package com.flipkart.drift.persistence.bootstrap;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class HbaseNamespaceConfig {
+    private String hot;
+    private String cold;
+    private String archival;
+    private String audit;
+}

--- a/commons/src/main/java/com/flipkart/drift/persistence/dao/ConnectionType.java
+++ b/commons/src/main/java/com/flipkart/drift/persistence/dao/ConnectionType.java
@@ -8,6 +8,9 @@ public enum ConnectionType {
 
     ConnectionType(String namespace) {
         this.namespace = namespace;
+        String envKey = "HBASE_NAMESPACE_" + this.name();
+        String overrideNamespace = System.getenv(envKey);
+        this.namespace = (overrideNamespace!=null && !overrideNamespace.isBlank()) ? overrideNamespace : namespace;
     }
 
     private final String namespace;

--- a/commons/src/main/java/com/flipkart/drift/persistence/dao/ConnectionType.java
+++ b/commons/src/main/java/com/flipkart/drift/persistence/dao/ConnectionType.java
@@ -7,7 +7,6 @@ public enum ConnectionType {
     HOT("ims_hot"),COLD("ims_cold"),ARCHIVAL("ims_archive"),AUDIT("ims_audit");
 
     ConnectionType(String namespace) {
-        this.namespace = namespace;
         String envKey = "HBASE_NAMESPACE_" + this.name();
         String overrideNamespace = System.getenv(envKey);
         this.namespace = (overrideNamespace!=null && !overrideNamespace.isBlank()) ? overrideNamespace : namespace;

--- a/commons/src/main/java/com/flipkart/drift/persistence/dao/ConnectionType.java
+++ b/commons/src/main/java/com/flipkart/drift/persistence/dao/ConnectionType.java
@@ -1,5 +1,6 @@
 package com.flipkart.drift.persistence.dao;
 
+import com.flipkart.drift.persistence.bootstrap.HbaseNamespaceConfig;
 import lombok.Getter;
 
 @Getter
@@ -7,11 +8,29 @@ public enum ConnectionType {
     HOT("ims_hot"),COLD("ims_cold"),ARCHIVAL("ims_archive"),AUDIT("ims_audit");
 
     ConnectionType(String namespace) {
-        String envKey = "HBASE_NAMESPACE_" + this.name();
-        String overrideNamespace = System.getenv(envKey);
-        this.namespace = (overrideNamespace!=null && !overrideNamespace.isBlank()) ? overrideNamespace : namespace;
+        this.namespace = namespace;
     }
 
-    private final String namespace;
+    private String namespace;
+
+    /**
+     * Applies namespace overrides from the Dropwizard config, replacing the compiled-in
+     * defaults. Must be called once during application startup
+     */
+    public static void init(HbaseNamespaceConfig config) {
+        if (config == null) {
+            return;
+        }
+        applyOverride(HOT, config.getHot());
+        applyOverride(COLD, config.getCold());
+        applyOverride(ARCHIVAL, config.getArchival());
+        applyOverride(AUDIT, config.getAudit());
+    }
+
+    private static void applyOverride(ConnectionType type, String namespace) {
+        if (namespace != null && !namespace.isBlank()) {
+            type.namespace = namespace;
+        }
+    }
 }
 

--- a/worker/src/main/java/com/flipkart/drift/worker/bootstrap/WorkerApplication.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/bootstrap/WorkerApplication.java
@@ -1,6 +1,7 @@
 package com.flipkart.drift.worker.bootstrap;
 
 import com.flipkart.drift.persistence.bootstrap.DriftEntityModule;
+import com.flipkart.drift.persistence.dao.ConnectionType;
 import com.flipkart.drift.worker.util.AuthNTokenGenerator;
 import com.flipkart.drift.worker.config.DriftWorkerConfiguration;
 import com.flipkart.drift.worker.resources.DriftWorkerResource;
@@ -46,6 +47,7 @@ public class WorkerApplication extends Application<DriftWorkerConfiguration> {
 
     @Override
     public void run(DriftWorkerConfiguration driftWorkerConfiguration, Environment environment) {
+        ConnectionType.init(driftWorkerConfiguration.getHbaseNamespaceConfig());
         Scope metricsScope = setupMetrics(driftWorkerConfiguration.getPrometheusConfig());
         ConcurrentCompositeConfiguration compositeConfiguration = getConcurrentCompositeConfiguration(driftWorkerConfiguration);
         DynamicPropertyFactory.initWithConfigurationSource(compositeConfiguration);

--- a/worker/src/main/java/com/flipkart/drift/worker/config/DriftWorkerConfiguration.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/config/DriftWorkerConfiguration.java
@@ -22,7 +22,7 @@ public class DriftWorkerConfiguration extends Configuration {
     private StaticCacheRefreshConfig staticCacheRefreshConfig;
     @NotNull
     private CacheMaxEntriesConfig cacheMaxEntriesConfig;
-    @NotNull
+    
     private HbaseNamespaceConfig hbaseNamespaceConfig;
     @NotNull
     private String hbasePropertiesPath;

--- a/worker/src/main/java/com/flipkart/drift/worker/config/DriftWorkerConfiguration.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/config/DriftWorkerConfiguration.java
@@ -2,6 +2,7 @@ package com.flipkart.drift.worker.config;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.flipkart.drift.persistence.bootstrap.CacheMaxEntriesConfig;
+import com.flipkart.drift.persistence.bootstrap.HbaseNamespaceConfig;
 import com.flipkart.drift.persistence.bootstrap.StaticCacheRefreshConfig;
 import io.dropwizard.Configuration;
 import lombok.Getter;
@@ -21,6 +22,8 @@ public class DriftWorkerConfiguration extends Configuration {
     private StaticCacheRefreshConfig staticCacheRefreshConfig;
     @NotNull
     private CacheMaxEntriesConfig cacheMaxEntriesConfig;
+    @NotNull
+    private HbaseNamespaceConfig hbaseNamespaceConfig;
     @NotNull
     private String hbasePropertiesPath;
     @NotNull

--- a/worker/src/main/resources/config/configuration.yaml
+++ b/worker/src/main/resources/config/configuration.yaml
@@ -42,6 +42,12 @@ authPropertiesPath: ${AUTH_PATH}
 
 workflowPropertiesPath: ${WORKFLOW_PROPERTY_PATH}
 
+hbaseNamespaceConfig:
+  hot: ${HBASE_NAMESPACE_HOT:-ims_hot}
+  cold: ${HBASE_NAMESPACE_COLD:-ims_cold}
+  archival: ${HBASE_NAMESPACE_ARCHIVAL:-ims_archive}
+  audit: ${HBASE_NAMESPACE_AUDIT:-ims_audit}
+
 prometheusConfig:
   port: 9090
   path: "/metrics"


### PR DESCRIPTION
Changes overview - https://docs.google.com/document/d/11QUGTGVNyeFAIlKo7Nh_T30c4LyDV6bvb2Vxr4gP_2o/edit?tab=t.361ioakrtliw#heading=h.qhmu2pa1ceda

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable HBase namespace overrides for hot, cold, archival, and audit datasets.
  * Namespaces are now initialized during service and worker startup to ensure HBase operations use the configured values.

* **Configuration**
  * Introduced a new `hbaseNamespaceConfig` section in YAML with `hot`, `cold`, `archival`, and `audit` values sourced from `HBASE_NAMESPACE_*` environment variables (defaults: `ims_hot`, `ims_cold`, `ims_archive`, `ims_audit`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->