### PR TITLE
Removal of dependency of AB Properties Path 

### DIFF
--- a/java-sdk/src/main/java/com/flipkart/drift/sdk/spi/ab/ABTestingProviderFactory.java
+++ b/java-sdk/src/main/java/com/flipkart/drift/sdk/spi/ab/ABTestingProviderFactory.java
@@ -23,8 +23,8 @@ public class ABTestingProviderFactory {
                 discovered = new NoOpABTestingProvider();
                 log.info("ABTestingProviderFactory: No custom ABTestingProvider found via SPI, using NoOpABTestingProvider");
             }
-        } catch (Throwable t) {
-            log.error("ABTestingProviderFactory : Failed to discover ABTestingProvider via SPI falling back to NoOpABTestingProvider", t);
+        } catch (ServiceConfigurationError | Exception e) {
+            log.error("ABTestingProviderFactory : Failed to discover ABTestingProvider via SPI falling back to NoOpABTestingProvider", e);
             discovered = new NoOpABTestingProvider();
         }
         provider = discovered;

--- a/java-sdk/src/main/java/com/flipkart/drift/sdk/spi/ab/ABTestingProviderFactory.java
+++ b/java-sdk/src/main/java/com/flipkart/drift/sdk/spi/ab/ABTestingProviderFactory.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Iterator;
 import java.util.ServiceLoader;
+import java.util.ServiceConfigurationError;
 
 @Slf4j
 public class ABTestingProviderFactory {

--- a/java-sdk/src/main/java/com/flipkart/drift/sdk/spi/ab/ABTestingProviderFactory.java
+++ b/java-sdk/src/main/java/com/flipkart/drift/sdk/spi/ab/ABTestingProviderFactory.java
@@ -18,7 +18,7 @@ public class ABTestingProviderFactory {
 
             if (iterator.hasNext()) {
                 discovered = iterator.next();
-                log.info("ABTestingProviderFactory: Discovered {} via SPI (not yet initialized)", provider.getClass().getName());
+                log.info("ABTestingProviderFactory: Discovered {} via SPI (not yet initialized)", discovered.getClass().getName());
             } else {
                 discovered = new NoOpABTestingProvider();
                 log.info("ABTestingProviderFactory: No custom ABTestingProvider found via SPI, using NoOpABTestingProvider");

--- a/java-sdk/src/main/java/com/flipkart/drift/sdk/spi/ab/ABTestingProviderFactory.java
+++ b/java-sdk/src/main/java/com/flipkart/drift/sdk/spi/ab/ABTestingProviderFactory.java
@@ -11,16 +11,23 @@ public class ABTestingProviderFactory {
 
     static {
         // Auto-discover ABTestingProvider implementations via ServiceLoader
-        ServiceLoader<ABTestingProvider> loader = ServiceLoader.load(ABTestingProvider.class);
-        Iterator<ABTestingProvider> iterator = loader.iterator();
-        
-        if (iterator.hasNext()) {
-            provider = iterator.next();
-            log.info("ABTestingProviderFactory: Discovered {} via SPI (not yet initialized)", provider.getClass().getName());
-        } else {
-            provider = new NoOpABTestingProvider();
-            log.info("ABTestingProviderFactory: No custom ABTestingProvider found via SPI, using NoOpABTestingProvider");
+        ABTestingProvider discovered;
+        try {
+            ServiceLoader<ABTestingProvider> loader = ServiceLoader.load(ABTestingProvider.class);
+            Iterator<ABTestingProvider> iterator = loader.iterator();
+
+            if (iterator.hasNext()) {
+                discovered = iterator.next();
+                log.info("ABTestingProviderFactory: Discovered {} via SPI (not yet initialized)", provider.getClass().getName());
+            } else {
+                discovered = new NoOpABTestingProvider();
+                log.info("ABTestingProviderFactory: No custom ABTestingProvider found via SPI, using NoOpABTestingProvider");
+            }
+        } catch (Throwable t) {
+            log.error("ABTestingProviderFactory : Failed to discover ABTestingProvider via SPI falling back to NoOpABTestingProvider", t);
+            discovered = new NoOpABTestingProvider();
         }
+        provider = discovered;
     }
 
     /**

--- a/worker/src/main/java/com/flipkart/drift/worker/Utility/ABServiceInitializer.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/Utility/ABServiceInitializer.java
@@ -2,6 +2,7 @@ package com.flipkart.drift.worker.Utility;
 
 import com.flipkart.drift.sdk.spi.ab.ABTestingProvider;
 import com.flipkart.drift.sdk.spi.ab.ABTestingProviderFactory;
+import com.flipkart.drift.sdk.spi.ab.NoOpABTestingProvider;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import lombok.Getter;
@@ -16,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 @Singleton
 public class ABServiceInitializer {
     
-    private final ABTestingProvider abTestingProvider;
+    private volatile ABTestingProvider abTestingProvider;
     
     @Getter
     private volatile boolean initialized = false;
@@ -44,12 +45,20 @@ public class ABServiceInitializer {
                 log.info("A/B Testing provider initialized successfully: {}", 
                         abTestingProvider.getClass().getSimpleName());
             } else {
-                log.error("A/B Testing provider initialization failed: AB Testing will be unavailable for this instance");
+                log.error("A/B Testing provider initialization failed: falling back to NoOpABTestingProvider");
+                disableABTesting();
             }
             
         } catch (Exception e) {
-            log.error("Failed to initialize A/B Testing provider: {}", e.getMessage(), e);
+            log.error("Failed to initialize A/B Testing provider: {}, Falling back to NoOpABTestingProvider", e.getMessage(), e);
+            disableABTesting();
         }
+    }
+
+    private void disableABTesting() {
+        NoOpABTestingProvider noOpABTestingProvider = new NoOpABTestingProvider();
+        noOpABTestingProvider.init();
+        this.abTestingProvider = noOpABTestingProvider;
     }
     
     /**

--- a/worker/src/main/java/com/flipkart/drift/worker/Utility/ABServiceInitializer.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/Utility/ABServiceInitializer.java
@@ -44,12 +44,11 @@ public class ABServiceInitializer {
                 log.info("A/B Testing provider initialized successfully: {}", 
                         abTestingProvider.getClass().getSimpleName());
             } else {
-                throw new RuntimeException("A/B Testing provider initialization failed");
+                log.error("A/B Testing provider initialization failed: AB Testing will be unavailable for this instance");
             }
             
         } catch (Exception e) {
             log.error("Failed to initialize A/B Testing provider: {}", e.getMessage(), e);
-            throw new RuntimeException("A/B Testing provider initialization failed", e);
         }
     }
     

--- a/worker/src/main/java/com/flipkart/drift/worker/Utility/ABServiceInitializer.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/Utility/ABServiceInitializer.java
@@ -59,6 +59,7 @@ public class ABServiceInitializer {
         NoOpABTestingProvider noOpABTestingProvider = new NoOpABTestingProvider();
         noOpABTestingProvider.init();
         this.abTestingProvider = noOpABTestingProvider;
+        this.initialized = true;
     }
     
     /**

--- a/worker/src/main/java/com/flipkart/drift/worker/bootstrap/WorkerApplication.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/bootstrap/WorkerApplication.java
@@ -22,10 +22,13 @@ import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.temporal.common.reporter.MicrometerClientStatsReporter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 public class WorkerApplication extends Application<DriftWorkerConfiguration> {
@@ -96,15 +99,23 @@ public class WorkerApplication extends Application<DriftWorkerConfiguration> {
     }
 
     private static ConcurrentCompositeConfiguration getConcurrentCompositeConfiguration(DriftWorkerConfiguration configuration) {
+        List<String> propertiesPath = new ArrayList<>(List.of(
+                configuration.getHbasePropertiesPath(),
+                configuration.getLookupPropertiesPath(),
+                configuration.getAuthPropertiesPath(),
+                configuration.getWorkflowPropertiesPath()
+        ));
+
+        String abPropertiesPath = configuration.getAbPropertiesPath();
+        if(StringUtils.isNotBlank(abPropertiesPath)){
+            propertiesPath.add(abPropertiesPath);
+        }
+
         DynamicURLConfiguration dynamicConfiguration = new DynamicURLConfiguration(
                 50000,
                 20000,
                 false,
-                configuration.getHbasePropertiesPath(),
-                configuration.getLookupPropertiesPath(),
-                configuration.getAuthPropertiesPath(),
-                configuration.getAbPropertiesPath(),
-                configuration.getWorkflowPropertiesPath()
+                propertiesPath.toArray(new String[0])
         );
         ConcurrentCompositeConfiguration compositeConfiguration =
                 new ConcurrentCompositeConfiguration();

--- a/worker/src/main/java/com/flipkart/drift/worker/config/DriftWorkerConfiguration.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/config/DriftWorkerConfiguration.java
@@ -46,6 +46,6 @@ public class DriftWorkerConfiguration extends Configuration {
     @NotNull
     private String authPropertiesPath;
 
-    @NotNull
+    //Optional : only required when a real (non-NoOp) ABTestingProvider is wired in via SPI
     private String abPropertiesPath;
 }

--- a/worker/src/main/resources/config/configuration.yaml
+++ b/worker/src/main/resources/config/configuration.yaml
@@ -37,8 +37,6 @@ lookupPropertiesPath: ${ENUM_STORE_BUCKET}
 
 hbasePropertiesPath: ${HBASE_CONFIG_BUCKET}
 
-abPropertiesPath: ${AB_CONFIG_BUCKET}
-
 authPropertiesPath: ${AUTH_PATH}
 
 workflowPropertiesPath: ${WORKFLOW_PROPERTY_PATH}


### PR DESCRIPTION
DOC : https://docs.google.com/document/d/11QUGTGVNyeFAIlKo7Nh_T30c4LyDV6bvb2Vxr4gP_2o/edit?tab=t.14m6jbymzmzt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Worker startup no longer fails if A/B testing provider initialization fails; it now logs the issue and falls back to a no-op provider.
  - A/B testing SPI discovery is now handled safely; failures during discovery fall back to a no-op provider instead of erroring.
  - A/B properties path is now optional: blank values are ignored during configuration loading, and validation was relaxed accordingly.
- **Documentation**
  - Removed the default A/B properties path entry from the sample configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->