### PR TITLE
Rm issuedetail dep

### DIFF
--- a/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
@@ -1,6 +1,7 @@
 package com.flipkart.drift.api.service;
 
 import com.flipkart.drift.api.config.DriftConfiguration;
+import com.flipkart.drift.api.config.RedisConfiguration;
 import com.flipkart.drift.api.filters.RequestThreadContext;
 import com.flipkart.drift.api.exception.ApiException;
 import com.flipkart.drift.sdk.model.enums.WorkflowExecutionMode;
@@ -114,7 +115,8 @@ public class TemporalService {
                         .build();
             } else {
                 // SYNC mode: block until workflow reaches a terminal state via Redis
-                if (!driftConfiguration.getRedisConfiguration().isRedisEnabled()) {
+                RedisConfiguration redisConfiguration = driftConfiguration.getRedisConfiguration();
+                if (redisConfiguration == null || !redisConfiguration.isRedisEnabled()) {
                     throw new ApiException(Response.Status.BAD_REQUEST,
                             "SYNC execution mode requires Redis to be enabled. " +
                             "Set executionMode=ASYNC or enable Redis (redisEnabled=true).");
@@ -194,7 +196,8 @@ public class TemporalService {
                 workflow.resumeWorkflow(workflowResumeRequest);
                 return buildResponseAndReturn(workflow);
             } else {
-                if (!driftConfiguration.getRedisConfiguration().isRedisEnabled()) {
+                RedisConfiguration redisConfiguration = driftConfiguration.getRedisConfiguration();
+                if (redisConfiguration == null || !redisConfiguration.isRedisEnabled()) {
                     throw new ApiException(Response.Status.BAD_REQUEST,
                             "SYNC execution mode requires Redis to be enabled. " +
                             "Set executionMode=ASYNC or enable Redis (redisEnabled=true).");

--- a/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
+++ b/api/src/main/java/com/flipkart/drift/api/service/TemporalService.java
@@ -1,6 +1,7 @@
 package com.flipkart.drift.api.service;
 
 import com.flipkart.drift.api.config.DriftConfiguration;
+import com.flipkart.drift.api.config.RedisConfiguration;
 import com.flipkart.drift.api.filters.RequestThreadContext;
 import com.flipkart.drift.api.exception.ApiException;
 import com.flipkart.drift.sdk.model.enums.WorkflowExecutionMode;
@@ -114,7 +115,8 @@ public class TemporalService {
                         .build();
             } else {
                 // SYNC mode: block until workflow reaches a terminal state via Redis
-                if (!driftConfiguration.getRedisConfiguration().isRedisEnabled()) {
+                RedisConfiguration redisConfiguration = driftConfiguration.getRedisConfiguration();
+                if (redisConfiguration != null && !redisConfiguration.isRedisEnabled()) {
                     throw new ApiException(Response.Status.BAD_REQUEST,
                             "SYNC execution mode requires Redis to be enabled. " +
                             "Set executionMode=ASYNC or enable Redis (redisEnabled=true).");
@@ -194,7 +196,8 @@ public class TemporalService {
                 workflow.resumeWorkflow(workflowResumeRequest);
                 return buildResponseAndReturn(workflow);
             } else {
-                if (!driftConfiguration.getRedisConfiguration().isRedisEnabled()) {
+                RedisConfiguration redisConfiguration = driftConfiguration.getRedisConfiguration();
+                if (redisConfiguration != null && !redisConfiguration.isRedisEnabled()) {
                     throw new ApiException(Response.Status.BAD_REQUEST,
                             "SYNC execution mode requires Redis to be enabled. " +
                             "Set executionMode=ASYNC or enable Redis (redisEnabled=true).");

--- a/commons/src/main/java/com/flipkart/drift/commons/model/temporal/WorkflowState.java
+++ b/commons/src/main/java/com/flipkart/drift/commons/model/temporal/WorkflowState.java
@@ -25,4 +25,7 @@ public class WorkflowState implements Serializable {
     private View view;
     private String currentNodeRef;
     private IssueDetail issueDetail;
+    // Resolved workflow DSL identity. Used to execute disconnected nodes when issueDetail is absent.
+    private String workflowDslId;
+    private String workflowVersion;
 }

--- a/java-sdk/src/main/java/com/flipkart/drift/sdk/model/request/WorkflowStartRequest.java
+++ b/java-sdk/src/main/java/com/flipkart/drift/sdk/model/request/WorkflowStartRequest.java
@@ -9,7 +9,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.Set;
 
@@ -20,7 +19,9 @@ import java.util.Set;
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class WorkflowStartRequest extends WorkflowRequest {
-    @NotNull(message = "issueDetail cannot be null")
+    // Optional/deprecated. Prefer params.workflowId + params.version for workflow resolution.
+    // Retained for backward compatibility: when params do not carry workflowId/version,
+    // issueDetail.issueId is used to look up the workflow mapping.
     @Deprecated
     private IssueDetail issueDetail;
     @Deprecated

--- a/worker/src/main/java/com/flipkart/drift/worker/activities/FetchWorkflowActivityImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/activities/FetchWorkflowActivityImpl.java
@@ -61,8 +61,9 @@ public class FetchWorkflowActivityImpl implements FetchWorkflowActivity {
 
     @Override
     public Workflow fetchWorkflowBasedOnRequest(WorkflowStartRequest request) {
-        String issueId = request.getIssueDetail().getIssueId();
         String tenant = request.getThreadContext().getOrDefault("tenant", "fk");
+
+        // Preferred path: explicit workflowId + version in params. No issueDetail required.
         if (request.getParams() != null) {
             Map<String, Object> params = request.getParams();
             Object workflowId = params.get(WORKFLOW_ID);
@@ -70,6 +71,15 @@ public class FetchWorkflowActivityImpl implements FetchWorkflowActivity {
             if (workflowId != null && version != null) {
                 return fetchWorkflow(workflowId.toString(), version.toString(), tenant);
             }
+        }
+
+        // Backward-compatible fallback: resolve workflow via issueId mapping.
+        String issueId = resolveIssueId(request);
+        if (issueId == null || issueId.trim().isEmpty()) {
+            throw Activity.wrap(new RuntimeException(
+                "Unable to resolve workflow: provide either params." + WORKFLOW_ID +
+                " and params." + VERSION + ", or a valid issueDetail.issueId."
+            ));
         }
 
         IssueWorkflowMapping issueWorkflowMapping = issueWorkflowMappingService.getIssueWorkflowMappingForIssue(issueId);
@@ -95,5 +105,9 @@ public class FetchWorkflowActivityImpl implements FetchWorkflowActivity {
     public WorkflowNode fetchWorkflowNode(String issueId, String nodeName, String tenant) {
         Workflow workflow = fetchWorkflowBasedOnIssueId(issueId, tenant);
         return workflow.getStates().get(nodeName);
+    }
+
+    private static String resolveIssueId(WorkflowStartRequest request) {
+        return request.getIssueDetail() != null ? request.getIssueDetail().getIssueId() : null;
     }
 }

--- a/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
@@ -21,6 +21,9 @@ import org.slf4j.Logger;
 
 import java.util.Map;
 
+import static com.flipkart.drift.worker.util.Constants.VERSION;
+import static com.flipkart.drift.worker.util.Constants.WORKFLOW_ID;
+
 @Data
 @Slf4j
 public class GenericWorkflowImpl implements com.flipkart.drift.workflows.GenericWorkflow {
@@ -42,7 +45,7 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
             Workflow workflow = fetchDsl(workflowStartRequest);
             if (workflow == null) {
                 throw ApplicationFailure.newNonRetryableFailure(
-                        "Workflow not found for issue: " + workflowStartRequest.getIssueDetail().getIssueId(),
+                        "Workflow not found for issueId: " + safeIssueId(workflowStartRequest),
                         "WORKFLOW_NOT_FOUND"
                 );
             }
@@ -122,27 +125,60 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
         this.workflowState.setWorkflowId(io.temporal.workflow.Workflow.getInfo().getWorkflowId());
         this.workflowState.setStatus(WorkflowStatus.CREATED);
         this.workflowState.setIssueDetail(workflowStartRequest.getIssueDetail());
+        // Capture explicit DSL identity so disconnected nodes can resolve without issueId.
+        if (workflowStartRequest.getParams() != null) {
+            Object dslWorkflowId = workflowStartRequest.getParams().get(WORKFLOW_ID);
+            Object dslVersion = workflowStartRequest.getParams().get(VERSION);
+            if (dslWorkflowId != null && dslVersion != null) {
+                this.workflowState.setWorkflowDslId(dslWorkflowId.toString());
+                this.workflowState.setWorkflowVersion(dslVersion.toString());
+            }
+        }
         io.temporal.workflow.Workflow.newActivityStub(WorkflowContextManagerActivity.class, OptionsStore.activityOptions)
                 .persistWorkflowState(workflowStartRequest, io.temporal.workflow.Workflow.getInfo().getWorkflowId());
     }
 
     private Workflow fetchDsl(WorkflowStartRequest workflowRequest) {
-        log.info("Fetching workflow DSL for issueId: {}", workflowRequest.getIssueDetail().getIssueId());
+        log.info("Fetching workflow DSL for issueId: {}", safeIssueId(workflowRequest));
         FetchWorkflowActivity fetchWorkflowActivity = io.temporal.workflow.Workflow.newActivityStub(
                 FetchWorkflowActivity.class, OptionsStore.activityOptions);
         return fetchWorkflowActivity.fetchWorkflowBasedOnRequest(workflowRequest);
 
     }
 
+    private static String safeIssueId(WorkflowStartRequest request) {
+        return request != null && request.getIssueDetail() != null
+                ? request.getIssueDetail().getIssueId() : null;
+    }
+
     @Timed(name = "workflow.execute.disconnected.duration")
     @Override
     public WorkflowUtilityResponse executeDisconnectedNode(WorkflowUtilityRequest workflowUtilityRequest) {
         String tenant = workflowUtilityRequest.getThreadContext().getOrDefault("tenant", "fk");
-        WorkflowNode workflowNode = io.temporal.workflow.Workflow.newActivityStub(
-                FetchWorkflowActivity.class,
-                OptionsStore.activityOptions).fetchWorkflowNode(
-                this.workflowState.getIssueDetail().getIssueId(),
-                workflowUtilityRequest.getNode(), tenant);
+        FetchWorkflowActivity fetchWorkflowActivity = io.temporal.workflow.Workflow.newActivityStub(
+                FetchWorkflowActivity.class, OptionsStore.activityOptions);
+        String node = workflowUtilityRequest.getNode();
+
+        String issueId = this.workflowState.getIssueDetail() != null
+                ? this.workflowState.getIssueDetail().getIssueId() : null;
+
+        WorkflowNode workflowNode;
+        if (issueId != null && !issueId.trim().isEmpty()) {
+            // Backward-compatible path: resolve via issue mapping.
+            workflowNode = fetchWorkflowActivity.fetchWorkflowNode(issueId, node, tenant);
+        } else if (this.workflowState.getWorkflowDslId() != null
+                && this.workflowState.getWorkflowVersion() != null) {
+            // issueId-free path: resolve directly via the workflow DSL identity captured at start.
+            Workflow workflow = fetchWorkflowActivity.fetchWorkflow(
+                    this.workflowState.getWorkflowDslId(),
+                    this.workflowState.getWorkflowVersion(), tenant);
+            workflowNode = workflow.getStates().get(node);
+        } else {
+            throw ApplicationFailure.newNonRetryableFailure(
+                    "Cannot execute disconnected node: workflow has neither issueId nor workflowId/version.",
+                    "WORKFLOW_RESOLUTION_FAILED"
+            );
+        }
         return nodeExecutor.executeWorkflowNode(workflowUtilityRequest, workflowNode);
     }
 }

--- a/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
+++ b/worker/src/main/java/com/flipkart/drift/worker/workflows/GenericWorkflowImpl.java
@@ -159,25 +159,27 @@ public class GenericWorkflowImpl implements com.flipkart.drift.workflows.Generic
                 FetchWorkflowActivity.class, OptionsStore.activityOptions);
         String node = workflowUtilityRequest.getNode();
 
-        String issueId = this.workflowState.getIssueDetail() != null
-                ? this.workflowState.getIssueDetail().getIssueId() : null;
-
         WorkflowNode workflowNode;
-        if (issueId != null && !issueId.trim().isEmpty()) {
-            // Backward-compatible path: resolve via issue mapping.
-            workflowNode = fetchWorkflowActivity.fetchWorkflowNode(issueId, node, tenant);
-        } else if (this.workflowState.getWorkflowDslId() != null
+        if (this.workflowState.getWorkflowDslId() != null
                 && this.workflowState.getWorkflowVersion() != null) {
-            // issueId-free path: resolve directly via the workflow DSL identity captured at start.
+            // Preferred path: resolve directly via the workflow DSL identity captured at start.
+            // Kept consistent with FetchWorkflowActivityImpl#fetchWorkflowBasedOnRequest, which
+            // also prefers params.workflowId/version over issueId.
             Workflow workflow = fetchWorkflowActivity.fetchWorkflow(
                     this.workflowState.getWorkflowDslId(),
                     this.workflowState.getWorkflowVersion(), tenant);
             workflowNode = workflow.getStates().get(node);
         } else {
-            throw ApplicationFailure.newNonRetryableFailure(
-                    "Cannot execute disconnected node: workflow has neither issueId nor workflowId/version.",
-                    "WORKFLOW_RESOLUTION_FAILED"
-            );
+            String issueId = this.workflowState.getIssueDetail() != null
+                    ? this.workflowState.getIssueDetail().getIssueId() : null;
+            if (issueId == null || issueId.trim().isEmpty()) {
+                throw ApplicationFailure.newNonRetryableFailure(
+                        "Cannot execute disconnected node: workflow has neither workflowId/version nor issueId.",
+                        "WORKFLOW_RESOLUTION_FAILED"
+                );
+            }
+            // Backward-compatible fallback: resolve via issue mapping.
+            workflowNode = fetchWorkflowActivity.fetchWorkflowNode(issueId, node, tenant);
         }
         return nodeExecutor.executeWorkflowNode(workflowUtilityRequest, workflowNode);
     }


### PR DESCRIPTION
**PR Description — What changed and why**

Problem

issueDetail was https://github.com/NotNull — so callers like the IRN flow (which knows the workflowId directly and has no concept of an "issue") were forced to send a dummy issueDetail object even though it served no purpose for them.

What was changed (4 files)

1. WorkflowStartRequest.java
Removed https://github.com/NotNull from issueDetail. Marked it @deprecated. It's now optional — callers who don't have an issue context no longer need to send it.

2. FetchWorkflowActivityImpl.java
Added a preferred resolution path: if params.workflowId + params.version are present, use them directly to fetch the workflow DSL — no issueDetail needed. Falls back to the old issueDetail.issueId → issue-workflow mapping path for existing callers. Throws a clear, actionable error if neither is provided.

3. GenericWorkflowImpl.java
Made all issueDetail accesses null-safe. Also saves workflowDslId + workflowVersion on WorkflowState at workflow start — so disconnected node execution can resolve the workflow DSL even when issueDetail is absent.

4. WorkflowState.java
Added two new fields: workflowDslId and workflowVersion. Purely additive — these get populated when the workflow is started via params.workflowId/version and are used later by disconnected node execution.

Why it's safe

All existing callers passing issueDetail continue to work unchanged (fallback path preserved)
No silent failures — if neither resolution path is available, a clear exception is thrown
Disconnected node execution is also covered via the new fields on WorkflowState
Testing Results

<img width="1880" height="1328" alt="image" src="https://github.com/user-attachments/assets/10ce4d0e-b1aa-4979-8c98-d987705d6432" />
<img width="1852" height="1392" alt="image" src="https://github.com/user-attachments/assets/aae6458a-48ee-49ff-976f-783a1ac45e39" />


Note: When neither issueDetail nor params.workflowId/version is provided, the activity throws an IllegalArgumentException with a descriptive message. Temporal currently retries this (causing API timeout) rather than failing fast. Making this exception non-retryable (ApplicationFailure.newNonRetryableFailure) is a follow-up improvement and is out of scope for this change — the primary goal of this PR is making issueDetail optional for callers who resolve workflows via params.workflowId.

Summary by CodeRabbit
New Features

Workflows can now execute using DSL identity (workflow ID and version) when issue details are unavailable, supporting disconnected node execution.
Improvements

Made issue details optional in workflow start requests for backward compatibility.
Added flexible workflow resolution using either configured parameters or a valid issue ID.
Improved validation and error messages when required workflow identification is missing.